### PR TITLE
Post-launch polish: 404 page, CSS link checking, content validation

### DIFF
--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -222,9 +222,40 @@ mod tests {
             !html.contains(r#"aria-current="page""#),
             "404 rail must mark nothing current: {html}"
         );
+        assert!(
+            !html.contains(r#"rel="canonical""#),
+            "404 page has no single stable URL, so it must not claim a canonical: {html}"
+        );
+        assert!(!html.contains("og:url"), "404 page must not emit og:url: {html}");
+        assert!(
+            html.contains(r#"<meta name="robots" content="noindex">"#),
+            "404 page must be noindexed: {html}"
+        );
 
         let sitemap = std::fs::read_to_string(tmp.join("sitemap.xml")).expect("sitemap written");
         assert!(!sitemap.contains("404"), "404 must not appear in the sitemap: {sitemap}");
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn build_gives_every_real_route_its_own_canonical_and_no_noindex() {
+        let tmp = std::env::temp_dir().join("site-build-test-canonical");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+        let site = Site::load(Path::new("../../content/site.toml")).unwrap();
+
+        for route in Route::ALL {
+            let html = std::fs::read_to_string(tmp.join(route.output_path())).unwrap();
+            let canonical = format!(r#"<link rel="canonical" href="{}{}">"#, site.url, route.path());
+            assert!(html.contains(&canonical), "{:?} missing its canonical: {html}", route);
+            assert!(
+                !html.contains("noindex"),
+                "{:?} must not be noindexed: {html}",
+                route
+            );
+        }
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -98,6 +98,11 @@ pub fn build(root: &Path, out: &Path, strict: bool) -> Result<Vec<PathBuf>> {
     write(&out.join("style.css"), &theme::stylesheet(), &mut written)?;
     write(&out.join("robots.txt"), &robots_txt(&site), &mut written)?;
     write(&out.join("sitemap.xml"), &sitemap_xml(&site), &mut written)?;
+    write(
+        &out.join("404.html"),
+        &pages::not_found::render(&site).into_string(),
+        &mut written,
+    )?;
     copy_tree(&root.join("static"), out, &mut written)?;
     copy_tree(&root.join("assets"), &out.join("assets"), &mut written)?;
 
@@ -198,6 +203,30 @@ mod tests {
             sitemap.contains("https://example.com/?a=1&amp;b=2"),
             "expected escaped ampersand in <loc>: {sitemap}"
         );
+    }
+
+    #[test]
+    fn build_writes_a_404_page_that_stays_out_of_the_sitemap() {
+        let tmp = std::env::temp_dir().join("site-build-test-404");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+
+        let html = std::fs::read_to_string(tmp.join("404.html")).expect("404.html written");
+        assert!(html.starts_with("<!DOCTYPE html>"));
+        assert!(
+            html.contains(&format!(r#"href="{}""#, Route::Index.path())),
+            "404 page must link back to the index: {html}"
+        );
+        assert!(
+            !html.contains(r#"aria-current="page""#),
+            "404 rail must mark nothing current: {html}"
+        );
+
+        let sitemap = std::fs::read_to_string(tmp.join("sitemap.xml")).expect("sitemap written");
+        assert!(!sitemap.contains("404"), "404 must not appear in the sitemap: {sitemap}");
+
+        std::fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]

--- a/crates/site/src/checks.rs
+++ b/crates/site/src/checks.rs
@@ -2,20 +2,31 @@ use anyhow::{bail, Result};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-/// Pulls every `href="..."` and `src="..."` value out of the HTML.
-fn references(html: &str) -> Vec<String> {
+/// Pulls every value that follows `marker` up to the next `"` out of `text`.
+fn extract_quoted(text: &str, marker: &str) -> Vec<String> {
     let mut found = Vec::new();
-    for attr in [r#"href=""#, r#"src=""#, r#"data=""#] {
-        let mut rest = html;
-        while let Some(start) = rest.find(attr) {
-            rest = &rest[start + attr.len()..];
-            if let Some(end) = rest.find('"') {
-                found.push(rest[..end].to_string());
-                rest = &rest[end..];
-            }
+    let mut rest = text;
+    while let Some(start) = rest.find(marker) {
+        rest = &rest[start + marker.len()..];
+        if let Some(end) = rest.find('"') {
+            found.push(rest[..end].to_string());
+            rest = &rest[end..];
         }
     }
     found
+}
+
+/// Pulls every `href="..."`, `src="..."`, and `data="..."` value out of the HTML.
+fn html_references(html: &str) -> Vec<String> {
+    [r#"href=""#, r#"src=""#, r#"data=""#]
+        .into_iter()
+        .flat_map(|marker| extract_quoted(html, marker))
+        .collect()
+}
+
+/// Pulls every `url("...")` value out of the CSS.
+fn css_references(css: &str) -> Vec<String> {
+    extract_quoted(css, r#"url(""#)
 }
 
 /// Maps a rooted site path to the file that must exist in `out`.
@@ -32,40 +43,52 @@ fn target(out: &Path, link: &str) -> PathBuf {
     }
 }
 
-fn html_files(dir: &Path, acc: &mut Vec<PathBuf>) -> Result<()> {
+fn files_with_extension(dir: &Path, ext: &str, acc: &mut Vec<PathBuf>) -> Result<()> {
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.is_dir() {
-            html_files(&path, acc)?;
-        } else if path.extension().is_some_and(|e| e == "html") {
+            files_with_extension(&path, ext, acc)?;
+        } else if path.extension().is_some_and(|e| e == ext) {
             acc.push(path);
         }
     }
     Ok(())
 }
 
-/// Fails the build if any internal link or asset reference does not resolve to
-/// a file in the output directory.
+/// Checks each rooted link's resolved target exists in `out`, recording any
+/// miss (attributed to `source`) in `broken`.
+fn check_links(source: &Path, links: &[String], out: &Path, strict: bool, broken: &mut BTreeSet<String>) {
+    for link in links {
+        if !link.starts_with('/') {
+            continue; // external, anchor, or relative — out of scope
+        }
+        if !strict && link.starts_with("/assets/") {
+            continue; // fetched from the private release; absent locally
+        }
+        let path = target(out, link);
+        if !path.exists() {
+            broken.insert(format!("{} → {}", source.display(), link));
+        }
+    }
+}
+
+/// Fails the build if any internal link, asset reference, or CSS `url()`
+/// reference does not resolve to a file in the output directory.
 pub fn verify(out: &Path, strict: bool) -> Result<()> {
     let mut pages = Vec::new();
-    html_files(out, &mut pages)?;
+    files_with_extension(out, "html", &mut pages)?;
+    let mut stylesheets = Vec::new();
+    files_with_extension(out, "css", &mut stylesheets)?;
 
     let mut broken = BTreeSet::new();
     for page in &pages {
         let html = std::fs::read_to_string(page)?;
-        for link in references(&html) {
-            if !link.starts_with('/') {
-                continue; // external, anchor, or relative — out of scope
-            }
-            if !strict && link.starts_with("/assets/") {
-                continue; // fetched from the private release; absent locally
-            }
-            let path = target(out, &link);
-            if !path.exists() {
-                broken.insert(format!("{} → {}", page.display(), link));
-            }
-        }
+        check_links(page, &html_references(&html), out, strict, &mut broken);
+    }
+    for sheet in &stylesheets {
+        let css = std::fs::read_to_string(sheet)?;
+        check_links(sheet, &css_references(&css), out, strict, &mut broken);
     }
 
     if !broken.is_empty() {
@@ -114,6 +137,35 @@ mod tests {
         let dir = scaffold("checks-asset", r#"<img src="/logo.svg">"#);
         let err = verify(&dir, true).expect_err("missing asset must fail the build");
         assert!(err.to_string().contains("/logo.svg"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rejects_a_missing_css_asset() {
+        let dir = scaffold("checks-css-missing", "<html></html>");
+        std::fs::write(
+            dir.join("style.css"),
+            r#"@font-face { src: url("/fonts/Missing.woff2") format("woff2"); }"#,
+        )
+        .unwrap();
+
+        let err = verify(&dir, true).expect_err("missing css asset must fail the build");
+        assert!(err.to_string().contains("/fonts/Missing.woff2"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn accepts_a_css_reference_that_resolves() {
+        let dir = scaffold("checks-css-ok", "<html></html>");
+        std::fs::create_dir_all(dir.join("fonts")).unwrap();
+        std::fs::write(dir.join("fonts/Inter.woff2"), b"").unwrap();
+        std::fs::write(
+            dir.join("style.css"),
+            r#"@font-face { src: url("/fonts/Inter.woff2") format("woff2"); }"#,
+        )
+        .unwrap();
+
+        assert!(verify(&dir, true).is_ok());
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/site/src/components/rail.rs
+++ b/crates/site/src/components/rail.rs
@@ -3,14 +3,15 @@ use crate::route::Route;
 use maud::{html, Markup};
 
 /// The persistent left rail from composition A. Collapses to a top bar
-/// under 640px via the stylesheet.
-pub fn rail(site: &Site, current: Route) -> Markup {
+/// under 640px via the stylesheet. `current` is `None` on pages that aren't
+/// any `Route` — the 404 page — so nothing in the nav is marked current.
+pub fn rail(site: &Site, current: Option<Route>) -> Markup {
     html! {
         div .rail {
             div .mono { "PM" }
             nav aria-label="Primary" {
                 @for route in Route::ALL {
-                    @if route == current {
+                    @if Some(route) == current {
                         a href=(route.path()) aria-current="page" { (route.label()) }
                     } @else {
                         a href=(route.path()) { (route.label()) }
@@ -57,7 +58,7 @@ mod tests {
 
     #[test]
     fn rail_lists_every_route_and_marks_the_current_one() {
-        let out = rail(&site(), Route::About).into_string();
+        let out = rail(&site(), Some(Route::About)).into_string();
         for r in Route::ALL {
             assert!(out.contains(r.label()), "missing nav entry {}", r.label());
         }
@@ -69,14 +70,26 @@ mod tests {
     }
 
     #[test]
+    fn rail_marks_nothing_current_when_given_none() {
+        let out = rail(&site(), None).into_string();
+        for r in Route::ALL {
+            assert!(out.contains(r.label()), "missing nav entry {}", r.label());
+        }
+        assert!(
+            !out.contains("aria-current=\"page\""),
+            "no nav entry should be marked current: {out}"
+        );
+    }
+
+    #[test]
     fn rail_shows_location() {
-        let out = rail(&site(), Route::Index).into_string();
+        let out = rail(&site(), Some(Route::Index)).into_string();
         assert!(out.contains("Washington, DC"));
     }
 
     #[test]
     fn rail_renders_an_accessible_theme_toggle_button() {
-        let out = rail(&site(), Route::Index).into_string();
+        let out = rail(&site(), Some(Route::Index)).into_string();
         assert!(out.contains("<button"), "toggle must be a real button element");
         assert!(
             out.contains(r#"aria-label="Toggle dark mode""#),
@@ -87,7 +100,7 @@ mod tests {
 
     #[test]
     fn rail_button_defaults_to_the_server_rendered_light_state_label() {
-        let out = rail(&site(), Route::Index).into_string();
+        let out = rail(&site(), Some(Route::Index)).into_string();
         let btn_start = out.find("<button").expect("button present");
         let btn_end = out.find("</button>").expect("closing button tag present") + "</button>".len();
         let button = &out[btn_start..btn_end];
@@ -99,7 +112,7 @@ mod tests {
 
     #[test]
     fn toggle_script_syncs_both_aria_pressed_and_the_visible_label() {
-        let out = rail(&site(), Route::Index).into_string();
+        let out = rail(&site(), Some(Route::Index)).into_string();
         // A double-quoted fragment, verbatim: if PreEscaped were removed, the
         // `"` characters would come out as `&quot;` and this would fail.
         assert!(

--- a/crates/site/src/components/shell.rs
+++ b/crates/site/src/components/shell.rs
@@ -41,19 +41,29 @@ pub fn page(site: &Site, route: Route, title: &str, body: Markup) -> Markup {
     }
 }
 
+/// Composition A: rail plus main column. `nav_current` drives which nav entry
+/// (if any) the rail marks with `aria-current`.
+fn composition(site: &Site, nav_current: Option<Route>, main: Markup) -> Markup {
+    html! {
+        div .layout {
+            (rail(site, nav_current))
+            main { (main) }
+        }
+    }
+}
+
 /// Composition A: rail plus main column, wrapped in the document shell.
 pub fn layout(site: &Site, current: Route, title: &str, main: Markup) -> Markup {
-    page(
-        site,
-        current,
-        title,
-        html! {
-            div .layout {
-                (rail(site, current))
-                main { (main) }
-            }
-        },
-    )
+    page(site, current, title, composition(site, Some(current), main))
+}
+
+/// The document shell for `dist/404.html`. GitHub Pages serves this file
+/// verbatim for any request that doesn't match a real path, so it isn't tied
+/// to a `Route`: `Route::ALL` drives the nav, the sitemap, and the build
+/// loop, and a 404 entry belongs in none of those. The rail marks nothing
+/// current; `Route::Index` is used only for `page`'s canonical/OG plumbing.
+pub fn not_found(site: &Site, title: &str, main: Markup) -> Markup {
+    page(site, Route::Index, title, composition(site, None, main))
 }
 
 #[cfg(test)]
@@ -198,5 +208,19 @@ mod tests {
         assert!(out.contains(r#"class="rail""#));
         assert!(out.contains("<main>"));
         assert!(out.contains("<p>body</p>"));
+    }
+
+    #[test]
+    fn not_found_renders_the_full_document_with_nothing_marked_current() {
+        let site = fixture_site();
+        let out = not_found(&site, "Not Found", html! { p { "gone" } }).into_string();
+        assert!(out.starts_with("<!DOCTYPE html>"), "missing doctype: {out}");
+        assert!(out.contains(r#"class="layout""#));
+        assert!(out.contains(r#"class="rail""#));
+        assert!(out.contains("<p>gone</p>"));
+        assert!(
+            !out.contains(r#"aria-current="page""#),
+            "404 rail must mark nothing current: {out}"
+        );
     }
 }

--- a/crates/site/src/components/shell.rs
+++ b/crates/site/src/components/shell.rs
@@ -3,9 +3,14 @@ use crate::content::Site;
 use crate::route::Route;
 use maud::{html, Markup, DOCTYPE};
 
-/// Wraps page content in the full HTML document.
-pub fn page(site: &Site, route: Route, title: &str, body: Markup) -> Markup {
-    let canonical = format!("{}{}", site.url, route.path());
+/// Wraps page content in the full HTML document. `route` is `None` for pages
+/// that don't have one stable URL — the 404 page, served for every unmatched
+/// path — in which case no `<link rel="canonical">` or `og:url` is emitted
+/// (there is no correct URL to claim), and `<meta name="robots"
+/// content="noindex">` is added instead, so the page is kept out of search
+/// results outright rather than left to an absent-canonical inference.
+pub fn page(site: &Site, route: Option<Route>, title: &str, body: Markup) -> Markup {
+    let canonical = route.map(|r| format!("{}{}", site.url, r.path()));
     // Built once and reused for <title> and og:title so the two can never disagree.
     let full_title = format!("{title} · {}", site.name);
     let og_image = format!("{}/og-image.png", site.url);
@@ -17,14 +22,20 @@ pub fn page(site: &Site, route: Route, title: &str, body: Markup) -> Markup {
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (full_title) }
                 meta name="description" content=(site.description);
-                link rel="canonical" href=(canonical);
+                @if let Some(canonical) = &canonical {
+                    link rel="canonical" href=(canonical);
+                } @else {
+                    meta name="robots" content="noindex";
+                }
                 link rel="icon" type="image/svg+xml" href="/favicon.svg";
                 link rel="apple-touch-icon" href="/apple-touch-icon.png";
                 meta property="og:type" content="website";
                 meta property="og:site_name" content=(site.name);
                 meta property="og:title" content=(full_title);
                 meta property="og:description" content=(site.description);
-                meta property="og:url" content=(canonical);
+                @if let Some(canonical) = &canonical {
+                    meta property="og:url" content=(canonical);
+                }
                 meta property="og:image" content=(og_image);
                 meta name="twitter:card" content="summary_large_image";
                 link rel="stylesheet" href="/style.css";
@@ -54,16 +65,17 @@ fn composition(site: &Site, nav_current: Option<Route>, main: Markup) -> Markup 
 
 /// Composition A: rail plus main column, wrapped in the document shell.
 pub fn layout(site: &Site, current: Route, title: &str, main: Markup) -> Markup {
-    page(site, current, title, composition(site, Some(current), main))
+    page(site, Some(current), title, composition(site, Some(current), main))
 }
 
 /// The document shell for `dist/404.html`. GitHub Pages serves this file
 /// verbatim for any request that doesn't match a real path, so it isn't tied
 /// to a `Route`: `Route::ALL` drives the nav, the sitemap, and the build
-/// loop, and a 404 entry belongs in none of those. The rail marks nothing
-/// current; `Route::Index` is used only for `page`'s canonical/OG plumbing.
+/// loop, and a 404 entry belongs in none of those. Passing `None` through to
+/// `page` also means no canonical/`og:url` (a 404 has no single stable URL
+/// to claim) and a `noindex` directive; the rail marks nothing current.
 pub fn not_found(site: &Site, title: &str, main: Markup) -> Markup {
-    page(site, Route::Index, title, composition(site, None, main))
+    page(site, None, title, composition(site, None, main))
 }
 
 #[cfg(test)]
@@ -74,7 +86,7 @@ mod tests {
     #[test]
     fn page_emits_a_complete_document() {
         let site = fixture_site();
-        let out = page(&site, Route::About, "About", html! { p { "hello" } }).into_string();
+        let out = page(&site, Some(Route::About), "About", html! { p { "hello" } }).into_string();
         assert!(out.starts_with("<!DOCTYPE html>"), "missing doctype: {out}");
         assert!(out.contains(r#"<html lang="en">"#), "missing lang attribute");
         assert!(out.contains(&format!("<title>About · {}</title>", site.name)));
@@ -86,7 +98,7 @@ mod tests {
     #[test]
     fn page_makes_no_external_requests() {
         let site = fixture_site();
-        let out = page(&site, Route::Index, "Index", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::Index), "Index", html! { p { "x" } }).into_string();
         // site.url itself is https:// (canonical/OG); nothing else should be.
         for host in ["http://", "https://fonts.", "cdn.", "googleapis"] {
             assert!(!out.contains(host), "external reference {host} found in output");
@@ -96,7 +108,7 @@ mod tests {
     #[test]
     fn page_emits_description_canonical_and_icons() {
         let site = fixture_site();
-        let out = page(&site, Route::About, "About", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::About), "About", html! { p { "x" } }).into_string();
         assert!(
             out.contains(&format!(r#"<meta name="description" content="{}">"#, site.description)),
             "missing description meta: {out}"
@@ -112,8 +124,8 @@ mod tests {
     #[test]
     fn canonical_url_differs_between_routes() {
         let site = fixture_site();
-        let index = page(&site, Route::Index, "Index", html! { p { "x" } }).into_string();
-        let about = page(&site, Route::About, "About", html! { p { "x" } }).into_string();
+        let index = page(&site, Some(Route::Index), "Index", html! { p { "x" } }).into_string();
+        let about = page(&site, Some(Route::About), "About", html! { p { "x" } }).into_string();
 
         let index_canonical = format!(r#"<link rel="canonical" href="{}/">"#, site.url);
         let about_canonical = format!(r#"<link rel="canonical" href="{}/about/">"#, site.url);
@@ -126,7 +138,7 @@ mod tests {
     #[test]
     fn page_emits_og_and_twitter_tags() {
         let site = fixture_site();
-        let out = page(&site, Route::Projects, "Projects", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::Projects), "Projects", html! { p { "x" } }).into_string();
         assert!(out.contains(r#"<meta property="og:type" content="website">"#));
         assert!(out.contains(&format!(r#"<meta property="og:site_name" content="{}">"#, site.name)));
         assert!(out.contains(&format!(
@@ -151,7 +163,7 @@ mod tests {
     #[test]
     fn og_title_agrees_with_the_document_title() {
         let site = fixture_site();
-        let out = page(&site, Route::Resume, "Resume", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::Resume), "Resume", html! { p { "x" } }).into_string();
         assert!(out.contains(&format!("<title>Resume · {}</title>", site.name)));
         assert!(out.contains(&format!(
             r#"<meta property="og:title" content="Resume · {}">"#,
@@ -163,7 +175,7 @@ mod tests {
     fn title_and_og_title_come_from_site_name_not_a_hardcoded_literal() {
         let mut site = fixture_site();
         site.name = "Someone Else Entirely".to_string();
-        let out = page(&site, Route::About, "About", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::About), "About", html! { p { "x" } }).into_string();
 
         assert!(
             out.contains("<title>About · Someone Else Entirely</title>"),
@@ -185,7 +197,7 @@ mod tests {
     #[test]
     fn head_applies_the_stored_theme_before_first_paint() {
         let site = fixture_site();
-        let out = page(&site, Route::Index, "Index", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::Index), "Index", html! { p { "x" } }).into_string();
         // A double-quoted fragment, verbatim: if PreEscaped were removed, the
         // `"` characters would come out as `&quot;` and this would fail.
         assert!(
@@ -221,6 +233,42 @@ mod tests {
         assert!(
             !out.contains(r#"aria-current="page""#),
             "404 rail must mark nothing current: {out}"
+        );
+    }
+
+    #[test]
+    fn page_without_a_route_omits_canonical_and_og_url_but_keeps_other_og_tags() {
+        let site = fixture_site();
+        let out = page(&site, None, "Not Found", html! { p { "x" } }).into_string();
+        assert!(!out.contains(r#"rel="canonical""#), "canonical must be absent: {out}");
+        assert!(!out.contains("og:url"), "og:url must be absent: {out}");
+        assert!(
+            out.contains(r#"<meta name="robots" content="noindex">"#),
+            "missing noindex directive: {out}"
+        );
+        // The rest of the OG tags are still accurate for a page with no URL.
+        assert!(out.contains(r#"<meta property="og:type" content="website">"#));
+        assert!(out.contains(&format!(r#"<meta property="og:site_name" content="{}">"#, site.name)));
+        assert!(out.contains(&format!(
+            r#"<meta property="og:title" content="Not Found · {}">"#,
+            site.name
+        )));
+        assert!(out.contains(&format!(
+            r#"<meta property="og:description" content="{}">"#,
+            site.description
+        )));
+        assert!(out.contains(&format!(r#"<meta property="og:image" content="{}/og-image.png">"#, site.url)));
+    }
+
+    #[test]
+    fn not_found_page_has_no_canonical_or_og_url_and_is_noindexed() {
+        let site = fixture_site();
+        let out = not_found(&site, "Not Found", html! { p { "gone" } }).into_string();
+        assert!(!out.contains(r#"rel="canonical""#), "canonical must be absent: {out}");
+        assert!(!out.contains("og:url"), "og:url must be absent: {out}");
+        assert!(
+            out.contains(r#"<meta name="robots" content="noindex">"#),
+            "missing noindex directive: {out}"
         );
     }
 }

--- a/crates/site/src/content.rs
+++ b/crates/site/src/content.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -35,7 +35,23 @@ impl Site {
     pub fn load(path: &Path) -> Result<Self> {
         let raw = std::fs::read_to_string(path)
             .with_context(|| format!("reading {}", path.display()))?;
-        toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+        let site: Site =
+            toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+        site.validate(path)?;
+        Ok(site)
+    }
+
+    /// Rejects content that would render a broken-looking page. Empty `work`
+    /// or `about` produce a section header over nothing, or a bare heading —
+    /// a content mistake should fail the build loudly rather than ship.
+    fn validate(&self, path: &Path) -> Result<()> {
+        if self.about.is_empty() {
+            bail!("{}: `about` must not be empty", path.display());
+        }
+        if self.work.is_empty() {
+            bail!("{}: `work` must not be empty", path.display());
+        }
+        Ok(())
     }
 }
 
@@ -72,5 +88,59 @@ surprise = "should not parse"
 "#;
         let err = toml::from_str::<Site>(toml).expect_err("unknown field must fail");
         assert!(err.to_string().contains("surprise"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_work_is_rejected() {
+        let mut site = fixture_site();
+        site.work = vec![];
+        let err = site
+            .validate(Path::new("content/site.toml"))
+            .expect_err("empty work must be rejected");
+        assert!(err.to_string().contains("work"), "got: {err}");
+        assert!(err.to_string().contains("site.toml"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_about_is_rejected() {
+        let mut site = fixture_site();
+        site.about = vec![];
+        let err = site
+            .validate(Path::new("content/site.toml"))
+            .expect_err("empty about must be rejected");
+        assert!(err.to_string().contains("about"), "got: {err}");
+        assert!(err.to_string().contains("site.toml"), "got: {err}");
+    }
+
+    #[test]
+    fn load_rejects_empty_about_end_to_end() {
+        let tmp = std::env::temp_dir().join("site-content-empty-about.toml");
+        std::fs::write(
+            &tmp,
+            r#"
+name = "X"
+location = "Y"
+role = "Z"
+lede = "L"
+bio = "B"
+credential = "C"
+description = "D"
+url = "https://example.com"
+projects_intro = "P"
+about = []
+
+[[work]]
+title = "T"
+org = "O"
+year = "2020"
+summary = "S"
+"#,
+        )
+        .unwrap();
+
+        let err = Site::load(&tmp).expect_err("empty about must fail Site::load");
+        assert!(err.to_string().contains("about"), "got: {err}");
+
+        std::fs::remove_file(&tmp).ok();
     }
 }

--- a/crates/site/src/pages/mod.rs
+++ b/crates/site/src/pages/mod.rs
@@ -1,4 +1,5 @@
 pub mod about;
 pub mod index;
+pub mod not_found;
 pub mod projects;
 pub mod resume;

--- a/crates/site/src/pages/not_found.rs
+++ b/crates/site/src/pages/not_found.rs
@@ -1,0 +1,44 @@
+use crate::components::shell;
+use crate::content::Site;
+use crate::route::Route;
+use maud::{html, Markup};
+
+/// `dist/404.html`. GitHub Pages serves this file for any request that
+/// doesn't resolve to a real path — including inbound links built against
+/// the pre-launch URL scheme (`/about.html`, now `/about/`). Deliberately
+/// not a `Route`: see `shell::not_found` for why.
+pub fn render(site: &Site) -> Markup {
+    let main = html! {
+        h1 { "Page not found" }
+        p .prose { "That link is out of date — the page moved or never existed." }
+        p { a href=(Route::Index.path()) { "Back to the index" } }
+    };
+    shell::not_found(site, "Not Found", main)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content::fixture_site;
+
+    #[test]
+    fn renders_a_heading_and_a_link_back_to_the_index() {
+        let site = fixture_site();
+        let out = render(&site).into_string();
+        assert!(out.contains("<h1>Page not found</h1>"), "missing heading: {out}");
+        assert!(
+            out.contains(&format!(r#"href="{}""#, Route::Index.path())),
+            "missing link back to the index: {out}"
+        );
+    }
+
+    #[test]
+    fn rail_marks_nothing_current() {
+        let site = fixture_site();
+        let out = render(&site).into_string();
+        assert!(
+            !out.contains(r#"aria-current="page""#),
+            "404 rail must mark nothing current: {out}"
+        );
+    }
+}

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -145,7 +145,7 @@ a:hover {{ text-decoration: underline; }}
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--muted);
-  background: transparent;
+  background: var(--surface);
   border: 1px solid var(--rule);
   border-radius: 3px;
   padding: 5px 9px;
@@ -220,14 +220,25 @@ mod tests {
     #[test]
     fn every_token_pair_meets_wcag_aa() {
         for (name, p) in [("light", LIGHT), ("dark", DARK)] {
-            for (label, fg) in [("ink", p.ink), ("muted", p.muted), ("accent", p.accent)] {
-                let ratio = contrast_ratio(fg, p.paper);
-                assert!(
-                    ratio >= 4.5,
-                    "{name}/{label} on paper is {ratio:.2}:1, below WCAG AA 4.5:1"
-                );
+            for (bg_label, bg) in [("paper", p.paper), ("surface", p.surface)] {
+                for (label, fg) in [("ink", p.ink), ("muted", p.muted), ("accent", p.accent)] {
+                    let ratio = contrast_ratio(fg, bg);
+                    assert!(
+                        ratio >= 4.5,
+                        "{name}/{label} on {bg_label} is {ratio:.2}:1, below WCAG AA 4.5:1"
+                    );
+                }
             }
         }
+    }
+
+    #[test]
+    fn theme_toggle_uses_the_surface_token_as_its_background() {
+        let css = stylesheet();
+        assert!(
+            css.contains("background: var(--surface);"),
+            "the --surface token has no consumer: {css}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to the generator rebuild, working through the deferred findings from its final review.

## Changes

- **404 page** at `dist/404.html`, styled like the rest of the site. GitHub Pages serves it for unmatched paths, which matters because the URL scheme changed at launch (`/about.html` → `/about/`). Deliberately *not* a `Route` variant — `Route::ALL` drives the nav and the sitemap, so a 404 in either would be a bug. It emits `noindex` and, unlike every other page, no `canonical` or `og:url`: a 404 serves for every unmatched path, so there is no URL it could honestly claim to be.
- **CSS link checking.** `checks::verify` previously scanned only HTML, so a `url()` reference in `style.css` went unchecked — a missing font would have shipped silently with every page falling back to system fonts. It now scans CSS through the same resolution path.
- **`--surface` has a consumer.** It backs the theme toggle button, and the WCAG contrast test now covers foreground tokens against `surface` as well as `paper` — 12 pairs instead of 6, since real text now sits on it.
- **Empty content fails the build.** `work = []` used to render a "Selected Work / 00" header above nothing, and `about = []` a bare heading. Both now error out naming the field and the file.

50 tests (up from 36), clippy clean at `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)