### PR TITLE
Reaction-diffusion WebAssembly demo (bucket 4)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
+        targets: wasm32-unknown-unknown
 
     - uses: Swatinem/rust-cache@v2
 
@@ -34,8 +35,20 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.RESUME_GITHUB_TOKEN }}
       run: ./scripts/fetch-resume.sh
 
+    - name: Install wasm-bindgen-cli
+      run: cargo install wasm-bindgen-cli --version 0.2.127 --locked
+
+    - name: Build WebAssembly
+      run: ./scripts/build-wasm.sh
+
     - name: Build site
       run: cargo run -p site -- --strict
+
+    - name: Verify wasm shipped
+      run: |
+        test -f dist/demos/reaction-diffusion/reaction_diffusion_bg.wasm
+        test -f dist/demos/reaction-diffusion/reaction_diffusion.js
+        ls -la dist/demos/reaction-diffusion/
 
     - name: Setup Pages
       uses: actions/configure-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 set_env.sh
 /assets/paul_maxwell_resume.pdf
 .superpowers/
+/static/demos/reaction-diffusion/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +105,19 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "reaction-diffusion"
+version = "0.1.0"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
@@ -209,6 +240,51 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/site"]
+members = ["crates/site", "crates/demos/reaction-diffusion"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/demos/reaction-diffusion/Cargo.toml
+++ b/crates/demos/reaction-diffusion/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "reaction-diffusion"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.127"

--- a/crates/demos/reaction-diffusion/src/grayscott.rs
+++ b/crates/demos/reaction-diffusion/src/grayscott.rs
@@ -42,6 +42,15 @@ impl Grid {
         self.b[y * self.width + x]
     }
 
+    // Only `reset_restores_the_initial_state` needs this — production code
+    // never reads A back out, only B (`paint` renders B; `step` reads/writes
+    // A internally). Gating it behind `cfg(test)` keeps it from being flagged
+    // as dead code in a real build while still existing for the test to call.
+    #[cfg(test)]
+    pub fn a_at(&self, x: usize, y: usize) -> f32 {
+        self.a[y * self.width + x]
+    }
+
     pub fn reset(&mut self) {
         self.a.fill(1.0);
         self.b.fill(0.0);
@@ -205,6 +214,7 @@ mod tests {
         for y in 0..16 {
             for x in 0..16 {
                 assert_eq!(g.b_at(x, y), 0.0, "reset left B behind at ({x},{y})");
+                assert_eq!(g.a_at(x, y), 1.0, "reset left A depleted at ({x},{y})");
             }
         }
     }

--- a/crates/demos/reaction-diffusion/src/grayscott.rs
+++ b/crates/demos/reaction-diffusion/src/grayscott.rs
@@ -1,0 +1,187 @@
+//! Gray-Scott reaction-diffusion, using Karl Sims' formulation.
+//!
+//! Deliberately free of any WebAssembly dependency so the physics can be
+//! tested natively rather than through a headless browser.
+
+const DA: f32 = 1.0;
+const DB: f32 = 0.5;
+const DT: f32 = 1.0;
+
+/// Two chemical concentration fields on a toroidal grid.
+pub struct Grid {
+    width: usize,
+    height: usize,
+    a: Vec<f32>,
+    b: Vec<f32>,
+    a_next: Vec<f32>,
+    b_next: Vec<f32>,
+}
+
+impl Grid {
+    pub fn new(width: usize, height: usize) -> Self {
+        let n = width * height;
+        Self {
+            width,
+            height,
+            a: vec![1.0; n],
+            b: vec![0.0; n],
+            a_next: vec![1.0; n],
+            b_next: vec![0.0; n],
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    pub fn b_at(&self, x: usize, y: usize) -> f32 {
+        self.b[y * self.width + x]
+    }
+
+    pub fn reset(&mut self) {
+        self.a.fill(1.0);
+        self.b.fill(0.0);
+    }
+
+    /// Fill a square of B, the disturbance the patterns grow from.
+    pub fn seed_rect(&mut self, cx: usize, cy: usize, half: usize) {
+        for dy in -(half as isize)..=(half as isize) {
+            for dx in -(half as isize)..=(half as isize) {
+                let x = (cx as isize + dx).rem_euclid(self.width as isize) as usize;
+                let y = (cy as isize + dy).rem_euclid(self.height as isize) as usize;
+                self.b[y * self.width + x] = 1.0;
+            }
+        }
+    }
+
+    /// Weighted 3×3 Laplacian with wrap-around, per Karl Sims: centre −1,
+    /// edge-adjacent 0.2, diagonal 0.05.
+    fn laplace(&self, field: &[f32], x: usize, y: usize) -> f32 {
+        let w = self.width as isize;
+        let h = self.height as isize;
+        let at = |dx: isize, dy: isize| -> f32 {
+            let nx = (x as isize + dx).rem_euclid(w) as usize;
+            let ny = (y as isize + dy).rem_euclid(h) as usize;
+            field[ny * self.width + nx]
+        };
+        -field[y * self.width + x]
+            + 0.2 * (at(-1, 0) + at(1, 0) + at(0, -1) + at(0, 1))
+            + 0.05 * (at(-1, -1) + at(1, -1) + at(-1, 1) + at(1, 1))
+    }
+
+    pub fn step(&mut self, feed: f32, kill: f32) {
+        for y in 0..self.height {
+            for x in 0..self.width {
+                let i = y * self.width + x;
+                let a = self.a[i];
+                let b = self.b[i];
+                let abb = a * b * b;
+                self.a_next[i] =
+                    (a + (DA * self.laplace(&self.a, x, y) - abb + feed * (1.0 - a)) * DT)
+                        .clamp(0.0, 1.0);
+                self.b_next[i] =
+                    (b + (DB * self.laplace(&self.b, x, y) + abb - (kill + feed) * b) * DT)
+                        .clamp(0.0, 1.0);
+            }
+        }
+        std::mem::swap(&mut self.a, &mut self.a_next);
+        std::mem::swap(&mut self.b, &mut self.b_next);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A = 1, B = 0 everywhere is an exact fixed point: the reaction term
+    /// A·B² is zero, feed f·(1 − A) is zero, kill (k + f)·B is zero, and the
+    /// Laplacian of a uniform field is zero. If stepping perturbs it, the
+    /// update rule is wrong.
+    #[test]
+    fn the_empty_state_is_a_fixed_point() {
+        let mut g = Grid::new(16, 16);
+        for _ in 0..50 {
+            g.step(0.0545, 0.0620);
+        }
+        for y in 0..g.height() {
+            for x in 0..g.width() {
+                assert!(g.b_at(x, y).abs() < 1e-6, "B drifted at ({x},{y})");
+            }
+        }
+    }
+
+    #[test]
+    fn seeding_introduces_b_and_it_spreads() {
+        let mut g = Grid::new(32, 32);
+        g.seed_rect(16, 16, 2);
+        assert!(g.b_at(16, 16) > 0.4, "seed did not take");
+        assert_eq!(g.b_at(0, 0), 0.0, "seed leaked across the grid");
+
+        for _ in 0..200 {
+            g.step(0.0545, 0.0620);
+        }
+        let spread = (10..22)
+            .flat_map(|y| (10..22).map(move |x| (x, y)))
+            .filter(|&(x, y)| g.b_at(x, y) > 0.01)
+            .count();
+        assert!(spread > 16, "B did not diffuse outward, only {spread} cells");
+    }
+
+    #[test]
+    fn values_stay_within_bounds() {
+        let mut g = Grid::new(24, 24);
+        g.seed_rect(12, 12, 3);
+        for _ in 0..500 {
+            g.step(0.0545, 0.0620);
+        }
+        for y in 0..g.height() {
+            for x in 0..g.width() {
+                let b = g.b_at(x, y);
+                assert!((0.0..=1.0).contains(&b), "B out of range at ({x},{y}): {b}");
+                assert!(b.is_finite(), "B diverged at ({x},{y})");
+            }
+        }
+    }
+
+    #[test]
+    fn the_grid_wraps_rather_than_clamping() {
+        // Seeding at the right edge must influence the left edge, which only
+        // happens if the Laplacian is toroidal.
+        let mut g = Grid::new(16, 16);
+        g.seed_rect(15, 8, 1);
+        for _ in 0..100 {
+            g.step(0.0545, 0.0620);
+        }
+        assert!(g.b_at(0, 8) > 0.001, "no wrap-around diffusion");
+    }
+
+    #[test]
+    fn simulation_is_deterministic() {
+        let run = || {
+            let mut g = Grid::new(16, 16);
+            g.seed_rect(8, 8, 2);
+            for _ in 0..100 {
+                g.step(0.0545, 0.0620);
+            }
+            (0..16).map(|i| g.b_at(i, i)).collect::<Vec<_>>()
+        };
+        assert_eq!(run(), run(), "same input produced different output");
+    }
+
+    #[test]
+    fn reset_restores_the_initial_state() {
+        let mut g = Grid::new(16, 16);
+        g.seed_rect(8, 8, 2);
+        g.step(0.0545, 0.0620);
+        g.reset();
+        for y in 0..16 {
+            for x in 0..16 {
+                assert_eq!(g.b_at(x, y), 0.0, "reset left B behind at ({x},{y})");
+            }
+        }
+    }
+}

--- a/crates/demos/reaction-diffusion/src/grayscott.rs
+++ b/crates/demos/reaction-diffusion/src/grayscott.rs
@@ -97,10 +97,13 @@ impl Grid {
 mod tests {
     use super::*;
 
-    /// A = 1, B = 0 everywhere is an exact fixed point: the reaction term
-    /// A·B² is zero, feed f·(1 − A) is zero, kill (k + f)·B is zero, and the
-    /// Laplacian of a uniform field is zero. If stepping perturbs it, the
-    /// update rule is wrong.
+    /// A = 1, B = 0 everywhere stays at B = 0 under stepping: every term in
+    /// B's update multiplies a zero B, regardless of the Laplacian's kernel
+    /// weights, so this does not pin the kernel — see
+    /// `laplacian_weights_are_exact` for that. What this does verify is that
+    /// `Grid::new` initialises to the correct steady state and that
+    /// repeated stepping introduces no numerical drift into a uniform
+    /// field.
     #[test]
     fn the_empty_state_is_a_fixed_point() {
         let mut g = Grid::new(16, 16);
@@ -147,16 +150,37 @@ mod tests {
         }
     }
 
+    /// A single seeded cell, one step later, has closed-form neighbour
+    /// values: an orthogonal neighbour gets `DB * 0.2 * 1.0 = 0.1` (its own
+    /// B, reaction, and kill terms are all zero since it starts at B = 0),
+    /// and a diagonal neighbour gets `DB * 0.05 * 1.0 = 0.025`. Asserting
+    /// both pins `DB`, the edge weight, and the diagonal weight at once —
+    /// change any one and this fails.
     #[test]
-    fn the_grid_wraps_rather_than_clamping() {
-        // Seeding at the right edge must influence the left edge, which only
-        // happens if the Laplacian is toroidal.
+    fn laplacian_weights_are_exact() {
+        let mut g = Grid::new(8, 8);
+        g.seed_rect(4, 4, 0);
+        g.step(0.0545, 0.0620);
+        let edge = g.b_at(5, 4);
+        let diagonal = g.b_at(5, 5);
+        assert!((edge - 0.1).abs() < 1e-6, "edge-adjacent neighbour: {edge}");
+        assert!(
+            (diagonal - 0.025).abs() < 1e-6,
+            "diagonal neighbour: {diagonal}"
+        );
+    }
+
+    /// A single cell seeded at the right edge (`half = 0`, so the seed
+    /// cannot itself wrap) must, after exactly one step, produce the same
+    /// closed-form 0.1 at its wrap-around neighbour on the left edge. A
+    /// clamping (non-toroidal) Laplacian would leave that cell at 0.
+    #[test]
+    fn wrap_is_immediate_across_the_edge() {
         let mut g = Grid::new(16, 16);
-        g.seed_rect(15, 8, 1);
-        for _ in 0..100 {
-            g.step(0.0545, 0.0620);
-        }
-        assert!(g.b_at(0, 8) > 0.001, "no wrap-around diffusion");
+        g.seed_rect(15, 8, 0);
+        g.step(0.0545, 0.0620);
+        let wrapped = g.b_at(0, 8);
+        assert!((wrapped - 0.1).abs() < 1e-6, "no wrap-around diffusion: {wrapped}");
     }
 
     #[test]

--- a/crates/demos/reaction-diffusion/src/lib.rs
+++ b/crates/demos/reaction-diffusion/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod grayscott;

--- a/crates/demos/reaction-diffusion/src/lib.rs
+++ b/crates/demos/reaction-diffusion/src/lib.rs
@@ -1,2 +1,64 @@
-pub mod grayscott;
-pub mod render;
+mod grayscott;
+mod render;
+
+use grayscott::Grid;
+use render::{paint, Palette};
+use wasm_bindgen::prelude::*;
+
+/// The simulation as JavaScript sees it.
+///
+/// Pixels live in wasm linear memory; JS reads them through a view rather
+/// than copying, so a frame costs one `putImageData` and no marshalling.
+#[wasm_bindgen]
+pub struct Simulation {
+    grid: Grid,
+    pixels: Vec<u8>,
+}
+
+#[wasm_bindgen]
+impl Simulation {
+    #[wasm_bindgen(constructor)]
+    pub fn new(width: usize, height: usize) -> Simulation {
+        Simulation {
+            grid: Grid::new(width, height),
+            pixels: vec![0; width * height * 4],
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        self.grid.width()
+    }
+
+    pub fn height(&self) -> usize {
+        self.grid.height()
+    }
+
+    /// Advance `substeps` iterations. More substeps per frame means faster
+    /// pattern evolution without a higher frame rate.
+    pub fn step(&mut self, feed: f32, kill: f32, substeps: u32) {
+        for _ in 0..substeps {
+            self.grid.step(feed, kill);
+        }
+    }
+
+    pub fn render(&mut self, dark: bool) {
+        let palette = if dark { Palette::Dark } else { Palette::Light };
+        paint(&self.grid, palette, &mut self.pixels);
+    }
+
+    pub fn seed(&mut self, x: usize, y: usize, half: usize) {
+        self.grid.seed_rect(x, y, half);
+    }
+
+    pub fn reset(&mut self) {
+        self.grid.reset();
+    }
+
+    pub fn pixels_ptr(&self) -> *const u8 {
+        self.pixels.as_ptr()
+    }
+
+    pub fn pixels_len(&self) -> usize {
+        self.pixels.len()
+    }
+}

--- a/crates/demos/reaction-diffusion/src/lib.rs
+++ b/crates/demos/reaction-diffusion/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod grayscott;
+pub mod render;

--- a/crates/demos/reaction-diffusion/src/lib.rs
+++ b/crates/demos/reaction-diffusion/src/lib.rs
@@ -25,10 +25,12 @@ impl Simulation {
         }
     }
 
+    /// Grid width in cells.
     pub fn width(&self) -> usize {
         self.grid.width()
     }
 
+    /// Grid height in cells.
     pub fn height(&self) -> usize {
         self.grid.height()
     }
@@ -46,18 +48,29 @@ impl Simulation {
         paint(&self.grid, palette, &mut self.pixels);
     }
 
+    /// Seed a square of reagent B centered at `(x, y)` with half-width `half`.
     pub fn seed(&mut self, x: usize, y: usize, half: usize) {
         self.grid.seed_rect(x, y, half);
     }
 
+    /// Clear the grid back to its initial (unseeded) state.
     pub fn reset(&mut self) {
         self.grid.reset();
     }
 
+    /// Pointer to the RGBA pixel buffer in wasm linear memory.
+    ///
+    /// The caller MUST rebuild its typed-array view from this pointer on
+    /// every frame and never cache it: if wasm memory grows, the backing
+    /// `ArrayBuffer` is detached and replaced, and a retained view reads
+    /// garbage or throws. `pixels` is allocated once and never resized, so
+    /// growth is unlikely here — but the rule costs nothing to follow and
+    /// the failure mode is silent.
     pub fn pixels_ptr(&self) -> *const u8 {
         self.pixels.as_ptr()
     }
 
+    /// Length in bytes of the buffer at `pixels_ptr`: `width * height * 4`.
     pub fn pixels_len(&self) -> usize {
         self.pixels.len()
     }

--- a/crates/demos/reaction-diffusion/src/render.rs
+++ b/crates/demos/reaction-diffusion/src/render.rs
@@ -74,6 +74,52 @@ mod tests {
         assert_ne!(bg, seeded, "seeded cell rendered identically to background");
     }
 
+    /// A seeded cell has `b = 1.0`, so `t = clamp(1.0 * 2.5, 0, 1) = 1.0` and
+    /// the pixel must be exactly the accent colour — not merely "different
+    /// from background" (`seeded_cells_differ_from_background`, above,
+    /// can't tell an accent-coloured pixel from a blue one, or a barely-off
+    /// -background one from a fully-saturated one). This pins both the
+    /// channel order and the `* 2.5` contrast scale at once.
+    #[test]
+    fn seeded_cell_is_exactly_the_accent_colour() {
+        let (x, y) = (1usize, 1usize);
+        let mut g = Grid::new(4, 4);
+        g.seed_rect(x, y, 0);
+
+        let mut light = vec![0u8; 4 * 4 * 4];
+        paint(&g, Palette::Light, &mut light);
+        let i = (y * g.width() + x) * 4;
+        assert_eq!(&light[i..i + 4], &[0xA8, 0x43, 0x1E, 255], "light accent mismatch");
+
+        let mut dark = vec![0u8; 4 * 4 * 4];
+        paint(&g, Palette::Dark, &mut dark);
+        assert_eq!(&dark[i..i + 4], &[0xE0, 0x76, 0x4A, 255], "dark accent mismatch");
+    }
+
+    /// A fully-seeded cell (`b = 1.0`) saturates to the accent colour under
+    /// *any* positive scale, so `seeded_cell_is_exactly_the_accent_colour`
+    /// cannot tell `* 2.5` from `* 1.0` apart — both clamp to `t = 1.0`.
+    /// This test uses a partially-saturated cell instead: per
+    /// `grayscott::laplacian_weights_are_exact`, a cell one step away from a
+    /// single seeded neighbour has the closed-form `b = 0.1`, giving
+    /// `t = clamp(0.1 * 2.5, 0, 1) = 0.25` — mid-blend, not clamped, so the
+    /// scale constant is the only unknown left in the output colour.
+    #[test]
+    fn a_partially_saturated_cell_reflects_the_contrast_scale() {
+        let mut g = Grid::new(8, 8);
+        g.seed_rect(4, 4, 0);
+        g.step(0.0545, 0.0620);
+
+        let mut light = vec![0u8; 8 * 8 * 4];
+        paint(&g, Palette::Light, &mut light);
+        let i = (4 * g.width() + 5) * 4; // edge-adjacent neighbour, b = 0.1
+        assert_eq!(&light[i..i + 4], &[0xE6, 0xCC, 0xC2, 255], "light mid-blend mismatch");
+
+        let mut dark = vec![0u8; 8 * 8 * 4];
+        paint(&g, Palette::Dark, &mut dark);
+        assert_eq!(&dark[i..i + 4], &[0x43, 0x29, 0x1F, 255], "dark mid-blend mismatch");
+    }
+
     #[test]
     fn palettes_differ() {
         let g = Grid::new(4, 4);

--- a/crates/demos/reaction-diffusion/src/render.rs
+++ b/crates/demos/reaction-diffusion/src/render.rs
@@ -1,0 +1,86 @@
+use crate::grayscott::Grid;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Palette {
+    Light,
+    Dark,
+}
+
+impl Palette {
+    /// (background, foreground) as RGB, taken from the site's design tokens
+    /// so the demo belongs to the page rather than sitting on it.
+    fn ends(self) -> ([u8; 3], [u8; 3]) {
+        match self {
+            // paper #FBFAF8 → accent #A8431E
+            Palette::Light => ([0xFB, 0xFA, 0xF8], [0xA8, 0x43, 0x1E]),
+            // paper #0E0F11 → accent #E0764A
+            Palette::Dark => ([0x0E, 0x0F, 0x11], [0xE0, 0x76, 0x4A]),
+        }
+    }
+}
+
+fn lerp(a: u8, b: u8, t: f32) -> u8 {
+    (f32::from(a) + (f32::from(b) - f32::from(a)) * t).round() as u8
+}
+
+/// Paint B concentration into an RGBA buffer laid out for `ImageData`.
+pub fn paint(grid: &Grid, palette: Palette, out: &mut [u8]) {
+    let (bg, fg) = palette.ends();
+    for y in 0..grid.height() {
+        for x in 0..grid.width() {
+            // B rarely exceeds ~0.4, so scale before clamping or the image
+            // stays nearly background-coloured.
+            let t = (grid.b_at(x, y) * 2.5).clamp(0.0, 1.0);
+            let i = (y * grid.width() + x) * 4;
+            out[i] = lerp(bg[0], fg[0], t);
+            out[i + 1] = lerp(bg[1], fg[1], t);
+            out[i + 2] = lerp(bg[2], fg[2], t);
+            out[i + 3] = 255;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paint_fills_every_pixel_opaque() {
+        let g = Grid::new(8, 8);
+        let mut buf = vec![0u8; 8 * 8 * 4];
+        paint(&g, Palette::Light, &mut buf);
+        for px in buf.chunks_exact(4) {
+            assert_eq!(px[3], 255, "alpha must be opaque");
+        }
+    }
+
+    #[test]
+    fn empty_grid_paints_the_background_colour() {
+        let g = Grid::new(4, 4);
+        let mut buf = vec![0u8; 4 * 4 * 4];
+        paint(&g, Palette::Light, &mut buf);
+        // B = 0 everywhere, so every pixel is the light paper colour #FBFAF8.
+        assert_eq!(&buf[0..3], &[0xFB, 0xFA, 0xF8]);
+    }
+
+    #[test]
+    fn seeded_cells_differ_from_background() {
+        let mut g = Grid::new(8, 8);
+        g.seed_rect(4, 4, 0);
+        let mut buf = vec![0u8; 8 * 8 * 4];
+        paint(&g, Palette::Light, &mut buf);
+        let bg = &buf[0..3];
+        let seeded = &buf[(4 * 8 + 4) * 4..(4 * 8 + 4) * 4 + 3];
+        assert_ne!(bg, seeded, "seeded cell rendered identically to background");
+    }
+
+    #[test]
+    fn palettes_differ() {
+        let g = Grid::new(4, 4);
+        let mut light = vec![0u8; 4 * 4 * 4];
+        let mut dark = vec![0u8; 4 * 4 * 4];
+        paint(&g, Palette::Light, &mut light);
+        paint(&g, Palette::Dark, &mut dark);
+        assert_ne!(light, dark, "light and dark rendered identically");
+    }
+}

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -91,6 +91,7 @@ pub fn build(root: &Path, out: &Path, strict: bool) -> Result<Vec<PathBuf>> {
             Route::About => pages::about::render(&site),
             Route::Projects => pages::projects::render(&site),
             Route::Resume => pages::resume::render(&site),
+            Route::Demos => pages::demos::render(&site),
         };
         write(&out.join(route.output_path()), &markup.into_string(), &mut written)?;
     }
@@ -173,7 +174,7 @@ mod tests {
             let loc = format!("<loc>{}{}</loc>", site.url, route.path());
             assert!(sitemap.contains(&loc), "sitemap missing {loc}: {sitemap}");
         }
-        assert!(!sitemap.contains("/demos/"), "demos must not exist until a later bucket");
+        assert!(sitemap.contains("/demos/"), "demos must be in the sitemap from bucket 4 on");
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -104,6 +104,11 @@ pub fn build(root: &Path, out: &Path, strict: bool) -> Result<Vec<PathBuf>> {
         &pages::not_found::render(&site).into_string(),
         &mut written,
     )?;
+    write(
+        &out.join("demos/reaction-diffusion/index.html"),
+        &pages::demo_reaction_diffusion::render(&site).into_string(),
+        &mut written,
+    )?;
     copy_tree(&root.join("static"), out, &mut written)?;
     copy_tree(&root.join("assets"), &out.join("assets"), &mut written)?;
 
@@ -235,6 +240,27 @@ mod tests {
 
         let sitemap = std::fs::read_to_string(tmp.join("sitemap.xml")).expect("sitemap written");
         assert!(!sitemap.contains("404"), "404 must not appear in the sitemap: {sitemap}");
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn build_writes_the_reaction_diffusion_demo_page_outside_the_sitemap() {
+        let tmp = std::env::temp_dir().join("site-build-test-rd-demo");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+
+        assert!(
+            tmp.join("demos/reaction-diffusion/index.html").exists(),
+            "reaction-diffusion demo page not written"
+        );
+
+        let sitemap = std::fs::read_to_string(tmp.join("sitemap.xml")).expect("sitemap written");
+        assert!(
+            !sitemap.contains("reaction-diffusion"),
+            "demo page is not a Route and must not appear in the sitemap: {sitemap}"
+        );
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -60,14 +60,23 @@ fn robots_txt(site: &Site) -> String {
 }
 
 /// A standard sitemap with one `<url>` per route — generated from
-/// `Route::ALL` so it cannot drift from the real route set.
-fn sitemap_xml(site: &Site) -> String {
+/// `Route::ALL` so it cannot drift from the real route set — plus `extra`
+/// absolute paths for real, linkable pages that aren't a top-level `Route`
+/// (the reaction-diffusion demo, nested under `/demos/`).
+fn sitemap_xml(site: &Site, extra: &[&str]) -> String {
     let mut urls = String::new();
     for route in Route::ALL {
         urls.push_str(&format!(
             "  <url><loc>{}{}</loc></url>\n",
             escape_xml(&site.url),
             escape_xml(route.path())
+        ));
+    }
+    for path in extra {
+        urls.push_str(&format!(
+            "  <url><loc>{}{}</loc></url>\n",
+            escape_xml(&site.url),
+            escape_xml(path)
         ));
     }
     format!(
@@ -98,7 +107,11 @@ pub fn build(root: &Path, out: &Path, strict: bool) -> Result<Vec<PathBuf>> {
 
     write(&out.join("style.css"), &theme::stylesheet(), &mut written)?;
     write(&out.join("robots.txt"), &robots_txt(&site), &mut written)?;
-    write(&out.join("sitemap.xml"), &sitemap_xml(&site), &mut written)?;
+    write(
+        &out.join("sitemap.xml"),
+        &sitemap_xml(&site, &[pages::demos::REACTION_DIFFUSION]),
+        &mut written,
+    )?;
     write(
         &out.join("404.html"),
         &pages::not_found::render(&site).into_string(),
@@ -200,7 +213,7 @@ mod tests {
             work: vec![],
         };
 
-        let sitemap = sitemap_xml(&site);
+        let sitemap = sitemap_xml(&site, &[]);
         assert!(
             !sitemap.contains("&b=2"),
             "raw unescaped ampersand leaked into sitemap: {sitemap}"
@@ -245,21 +258,29 @@ mod tests {
     }
 
     #[test]
-    fn build_writes_the_reaction_diffusion_demo_page_outside_the_sitemap() {
+    fn build_writes_the_reaction_diffusion_demo_page_and_lists_it_in_the_sitemap() {
         let tmp = std::env::temp_dir().join("site-build-test-rd-demo");
         let _ = std::fs::remove_dir_all(&tmp);
 
         build(Path::new("../.."), &tmp, false).expect("build succeeds");
+        let site = Site::load(Path::new("../../content/site.toml")).unwrap();
 
         assert!(
             tmp.join("demos/reaction-diffusion/index.html").exists(),
             "reaction-diffusion demo page not written"
         );
 
+        // Not a `Route`, but a real, stable, linkable URL and the flagship
+        // page of this bucket — it must be discoverable, not hidden because
+        // of an implementation detail of the generator.
         let sitemap = std::fs::read_to_string(tmp.join("sitemap.xml")).expect("sitemap written");
         assert!(
-            !sitemap.contains("reaction-diffusion"),
-            "demo page is not a Route and must not appear in the sitemap: {sitemap}"
+            sitemap.contains(&format!(
+                "<loc>{}{}</loc>",
+                site.url,
+                pages::demos::REACTION_DIFFUSION
+            )),
+            "demo page missing from the sitemap: {sitemap}"
         );
 
         std::fs::remove_dir_all(&tmp).ok();
@@ -283,6 +304,72 @@ mod tests {
                 route
             );
         }
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn demo_page_claims_its_own_canonical_not_its_parent_routes() {
+        let tmp = std::env::temp_dir().join("site-build-test-demo-canonical");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+        let site = Site::load(Path::new("../../content/site.toml")).unwrap();
+
+        // `build_gives_every_real_route_its_own_canonical_and_no_noindex`
+        // loops `Route::ALL` and so cannot see this page — it is nested
+        // under `/demos/` but is not itself a `Route`.
+        let html = std::fs::read_to_string(tmp.join("demos/reaction-diffusion/index.html"))
+            .expect("demo page written");
+        let expected_url = format!("{}{}", site.url, pages::demos::REACTION_DIFFUSION);
+        assert!(
+            html.contains(&format!(r#"<link rel="canonical" href="{expected_url}">"#)),
+            "demo page canonical must be its own URL, not /demos/: {html}"
+        );
+        assert!(
+            html.contains(&format!(r#"<meta property="og:url" content="{expected_url}">"#)),
+            "demo page og:url must be its own URL, not /demos/: {html}"
+        );
+        assert!(!html.contains("noindex"), "demo page must not be noindexed: {html}");
+
+        // Every real Route, plus the demo page above, still claims a
+        // distinct, correct canonical of its own.
+        for route in Route::ALL {
+            let html = std::fs::read_to_string(tmp.join(route.output_path())).unwrap();
+            let canonical = format!(r#"<link rel="canonical" href="{}{}">"#, site.url, route.path());
+            assert!(html.contains(&canonical), "{:?} missing its canonical: {html}", route);
+        }
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn wasm_loader_is_referenced_only_by_the_demo_page() {
+        let tmp = std::env::temp_dir().join("site-build-test-wasm-scope");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+
+        for route in Route::ALL {
+            let html = std::fs::read_to_string(tmp.join(route.output_path())).unwrap();
+            assert!(
+                !html.contains("loader.js"),
+                "{:?} must not download the wasm demo loader: {html}",
+                route
+            );
+        }
+        let not_found = std::fs::read_to_string(tmp.join("404.html")).unwrap();
+        assert!(
+            !not_found.contains("loader.js"),
+            "404 page must not download the wasm demo loader: {not_found}"
+        );
+
+        let demo_html = std::fs::read_to_string(tmp.join("demos/reaction-diffusion/index.html"))
+            .expect("demo page written");
+        assert!(
+            demo_html.contains("loader.js"),
+            "demo page must load the wasm demo: {demo_html}"
+        );
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/site/src/checks.rs
+++ b/crates/site/src/checks.rs
@@ -126,9 +126,9 @@ mod tests {
 
     #[test]
     fn rejects_a_dead_internal_link() {
-        let dir = scaffold("checks-dead", r#"<a href="/demos/">Demos</a>"#);
+        let dir = scaffold("checks-dead", r#"<a href="/nonexistent-page/">Nonexistent</a>"#);
         let err = verify(&dir, true).expect_err("dead link must fail the build");
-        assert!(err.to_string().contains("/demos/"), "got: {err}");
+        assert!(err.to_string().contains("/nonexistent-page/"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/site/src/components/rail.rs
+++ b/crates/site/src/components/rail.rs
@@ -66,7 +66,7 @@ mod tests {
             out.contains(r#"href="/about/" aria-current="page""#),
             "current page not marked: {out}"
         );
-        assert!(!out.contains("Demos"), "Demos must not be linked in bucket 1");
+        assert!(out.contains("Demos"), "Demos must be linked from bucket 4 on");
     }
 
     #[test]

--- a/crates/site/src/components/shell.rs
+++ b/crates/site/src/components/shell.rs
@@ -3,14 +3,18 @@ use crate::content::Site;
 use crate::route::Route;
 use maud::{html, Markup, DOCTYPE};
 
-/// Wraps page content in the full HTML document. `route` is `None` for pages
-/// that don't have one stable URL — the 404 page, served for every unmatched
-/// path — in which case no `<link rel="canonical">` or `og:url` is emitted
-/// (there is no correct URL to claim), and `<meta name="robots"
-/// content="noindex">` is added instead, so the page is kept out of search
-/// results outright rather than left to an absent-canonical inference.
-pub fn page(site: &Site, route: Option<Route>, title: &str, body: Markup) -> Markup {
-    let canonical = route.map(|r| format!("{}{}", site.url, r.path()));
+/// Wraps page content in the full HTML document. `canonical_path` is the
+/// site-relative path (e.g. `/about/`) this page claims as its one stable
+/// URL — deliberately a plain path rather than a `Route`, since not every
+/// page that needs a canonical is a top-level `Route` (see `sub_page`).
+/// `None` means the page has no single stable URL — the 404 page, served
+/// for every unmatched path — in which case no `<link rel="canonical">` or
+/// `og:url` is emitted (there is no correct URL to claim), and `<meta
+/// name="robots" content="noindex">` is added instead, so the page is kept
+/// out of search results outright rather than left to an absent-canonical
+/// inference.
+pub fn page(site: &Site, canonical_path: Option<&str>, title: &str, body: Markup) -> Markup {
+    let canonical = canonical_path.map(|p| format!("{}{}", site.url, p));
     // Built once and reused for <title> and og:title so the two can never disagree.
     let full_title = format!("{title} · {}", site.name);
     let og_image = format!("{}/og-image.png", site.url);
@@ -63,9 +67,29 @@ fn composition(site: &Site, nav_current: Option<Route>, main: Markup) -> Markup 
     }
 }
 
-/// Composition A: rail plus main column, wrapped in the document shell.
+/// Composition A: rail plus main column, wrapped in the document shell. The
+/// page currently marked in the rail also claims that route's own path as
+/// its canonical URL — the common case, where "what's current in the nav"
+/// and "what URL this page is" are the same thing.
 pub fn layout(site: &Site, current: Route, title: &str, main: Markup) -> Markup {
-    page(site, Some(current), title, composition(site, Some(current), main))
+    page(site, Some(current.path()), title, composition(site, Some(current), main))
+}
+
+/// Composition A for a page that lives *under* a nav item rather than *at*
+/// it — e.g. a demo page nested under the Demos route. `nav_current` marks
+/// the rail as `layout` would, but `canonical_path` is threaded through to
+/// `page` independently, so the page claims its own URL instead of
+/// borrowing its parent's. Without this split, every sub-page would tell
+/// search engines it's a duplicate of its parent route and point share
+/// cards at the wrong URL.
+pub fn sub_page(
+    site: &Site,
+    nav_current: Route,
+    canonical_path: &str,
+    title: &str,
+    main: Markup,
+) -> Markup {
+    page(site, Some(canonical_path), title, composition(site, Some(nav_current), main))
 }
 
 /// The document shell for `dist/404.html`. GitHub Pages serves this file
@@ -86,7 +110,7 @@ mod tests {
     #[test]
     fn page_emits_a_complete_document() {
         let site = fixture_site();
-        let out = page(&site, Some(Route::About), "About", html! { p { "hello" } }).into_string();
+        let out = page(&site, Some(Route::About.path()), "About", html! { p { "hello" } }).into_string();
         assert!(out.starts_with("<!DOCTYPE html>"), "missing doctype: {out}");
         assert!(out.contains(r#"<html lang="en">"#), "missing lang attribute");
         assert!(out.contains(&format!("<title>About · {}</title>", site.name)));
@@ -98,7 +122,7 @@ mod tests {
     #[test]
     fn page_makes_no_external_requests() {
         let site = fixture_site();
-        let out = page(&site, Some(Route::Index), "Index", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::Index.path()), "Index", html! { p { "x" } }).into_string();
         // site.url itself is https:// (canonical/OG); nothing else should be.
         for host in ["http://", "https://fonts.", "cdn.", "googleapis"] {
             assert!(!out.contains(host), "external reference {host} found in output");
@@ -108,7 +132,7 @@ mod tests {
     #[test]
     fn page_emits_description_canonical_and_icons() {
         let site = fixture_site();
-        let out = page(&site, Some(Route::About), "About", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::About.path()), "About", html! { p { "x" } }).into_string();
         assert!(
             out.contains(&format!(r#"<meta name="description" content="{}">"#, site.description)),
             "missing description meta: {out}"
@@ -124,8 +148,8 @@ mod tests {
     #[test]
     fn canonical_url_differs_between_routes() {
         let site = fixture_site();
-        let index = page(&site, Some(Route::Index), "Index", html! { p { "x" } }).into_string();
-        let about = page(&site, Some(Route::About), "About", html! { p { "x" } }).into_string();
+        let index = page(&site, Some(Route::Index.path()), "Index", html! { p { "x" } }).into_string();
+        let about = page(&site, Some(Route::About.path()), "About", html! { p { "x" } }).into_string();
 
         let index_canonical = format!(r#"<link rel="canonical" href="{}/">"#, site.url);
         let about_canonical = format!(r#"<link rel="canonical" href="{}/about/">"#, site.url);
@@ -138,7 +162,7 @@ mod tests {
     #[test]
     fn page_emits_og_and_twitter_tags() {
         let site = fixture_site();
-        let out = page(&site, Some(Route::Projects), "Projects", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::Projects.path()), "Projects", html! { p { "x" } }).into_string();
         assert!(out.contains(r#"<meta property="og:type" content="website">"#));
         assert!(out.contains(&format!(r#"<meta property="og:site_name" content="{}">"#, site.name)));
         assert!(out.contains(&format!(
@@ -163,7 +187,7 @@ mod tests {
     #[test]
     fn og_title_agrees_with_the_document_title() {
         let site = fixture_site();
-        let out = page(&site, Some(Route::Resume), "Resume", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::Resume.path()), "Resume", html! { p { "x" } }).into_string();
         assert!(out.contains(&format!("<title>Resume · {}</title>", site.name)));
         assert!(out.contains(&format!(
             r#"<meta property="og:title" content="Resume · {}">"#,
@@ -175,7 +199,7 @@ mod tests {
     fn title_and_og_title_come_from_site_name_not_a_hardcoded_literal() {
         let mut site = fixture_site();
         site.name = "Someone Else Entirely".to_string();
-        let out = page(&site, Some(Route::About), "About", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::About.path()), "About", html! { p { "x" } }).into_string();
 
         assert!(
             out.contains("<title>About · Someone Else Entirely</title>"),
@@ -197,7 +221,7 @@ mod tests {
     #[test]
     fn head_applies_the_stored_theme_before_first_paint() {
         let site = fixture_site();
-        let out = page(&site, Some(Route::Index), "Index", html! { p { "x" } }).into_string();
+        let out = page(&site, Some(Route::Index.path()), "Index", html! { p { "x" } }).into_string();
         // A double-quoted fragment, verbatim: if PreEscaped were removed, the
         // `"` characters would come out as `&quot;` and this would fail.
         assert!(

--- a/crates/site/src/pages/demo_reaction_diffusion.rs
+++ b/crates/site/src/pages/demo_reaction_diffusion.rs
@@ -1,0 +1,54 @@
+use crate::components::shell;
+use crate::content::Site;
+use crate::route::Route;
+use maud::{html, Markup};
+
+pub fn render(site: &Site) -> Markup {
+    let main = html! {
+        h1 { "Reaction-Diffusion" }
+        p .prose {
+            "Two chemicals diffuse across a grid at different rates; one converts the other on contact. "
+            "That single rule, iterated, produces patterns that look like coral, cell division, or fingerprints. "
+            "The whole simulation runs in Rust compiled to WebAssembly — click the canvas to disturb it."
+        }
+
+        canvas #rd-canvas .rd-canvas {}
+
+        div .rd-controls {
+            button #rd-toggle .theme-toggle type="button" { "Pause" }
+            button #rd-reset .theme-toggle type="button" { "Reset" }
+            @for (id, label) in [("coral", "Coral"), ("mitosis", "Mitosis"), ("solitons", "Solitons"), ("worms", "Worms")] {
+                button .theme-toggle type="button" data-preset=(id) { (label) }
+            }
+            span #rd-status .mono { "loading" }
+        }
+
+        noscript {
+            p .prose { "This demo needs JavaScript and WebAssembly. The rest of the site works without either." }
+        }
+
+        script type="module" src="/demos/loader.js" {}
+    };
+    shell::layout(site, Route::Demos, "Reaction-Diffusion", main)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demo_page_has_a_canvas_and_loads_the_module_lazily() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(r#"id="rd-canvas""#), "canvas missing");
+        assert!(out.contains(r#"type="module""#), "module script missing");
+        assert!(out.contains("/demos/loader.js"), "loader not referenced");
+        assert!(out.contains(r#"data-preset="coral""#), "presets missing");
+        assert!(out.contains("noscript"), "no fallback for JS-disabled visitors");
+    }
+
+    #[test]
+    fn demo_page_marks_demos_as_the_current_nav_item() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(r#"href="/demos/" aria-current="page""#));
+    }
+}

--- a/crates/site/src/pages/demo_reaction_diffusion.rs
+++ b/crates/site/src/pages/demo_reaction_diffusion.rs
@@ -12,7 +12,7 @@ pub fn render(site: &Site) -> Markup {
             "The whole simulation runs in Rust compiled to WebAssembly — click the canvas to disturb it."
         }
 
-        canvas #rd-canvas .rd-canvas {}
+        canvas #rd-canvas .rd-canvas aria-label="Reaction-diffusion simulation" {}
 
         div .rd-controls {
             button #rd-toggle .theme-toggle type="button" { "Pause" }
@@ -44,6 +44,10 @@ mod tests {
         assert!(out.contains("/demos/loader.js"), "loader not referenced");
         assert!(out.contains(r#"data-preset="coral""#), "presets missing");
         assert!(out.contains("noscript"), "no fallback for JS-disabled visitors");
+        assert!(
+            out.contains(r#"aria-label="Reaction-diffusion simulation""#),
+            "canvas missing an accessible label"
+        );
     }
 
     #[test]

--- a/crates/site/src/pages/demo_reaction_diffusion.rs
+++ b/crates/site/src/pages/demo_reaction_diffusion.rs
@@ -29,7 +29,13 @@ pub fn render(site: &Site) -> Markup {
 
         script type="module" src="/demos/loader.js" {}
     };
-    shell::layout(site, Route::Demos, "Reaction-Diffusion", main)
+    shell::sub_page(
+        site,
+        Route::Demos,
+        crate::pages::demos::REACTION_DIFFUSION,
+        "Reaction-Diffusion",
+        main,
+    )
 }
 
 #[cfg(test)]

--- a/crates/site/src/pages/demos.rs
+++ b/crates/site/src/pages/demos.rs
@@ -1,0 +1,39 @@
+use crate::components::shell;
+use crate::content::Site;
+use crate::route::Route;
+use maud::{html, Markup};
+
+/// Path of the reaction-diffusion demo page. Task 5 renders it.
+pub const REACTION_DIFFUSION: &str = "/demos/reaction-diffusion/";
+
+pub fn render(site: &Site) -> Markup {
+    let main = html! {
+        h1 { "Demos" }
+        p .prose { "Small things built in Rust, compiled to WebAssembly, running in your browser." }
+        div .section-head {
+            span .mono { "Demos" }
+            span .mono { "01" }
+        }
+        div .item {
+            div {
+                h3 { a href=(REACTION_DIFFUSION) { "Reaction-Diffusion" } }
+                p { "A Gray-Scott simulation: two chemicals, one feeding on the other, painting patterns that look uncannily biological. Every pixel is computed in Rust, sixty times a second." }
+            }
+            div .mono .year { "2026" }
+        }
+    };
+    shell::layout(site, Route::Demos, "Demos", main)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demos_index_links_to_the_reaction_diffusion_demo() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(REACTION_DIFFUSION), "demo link missing");
+        assert!(out.contains("Reaction-Diffusion"));
+        assert!(out.contains(r#"href="/demos/" aria-current="page""#));
+    }
+}

--- a/crates/site/src/pages/mod.rs
+++ b/crates/site/src/pages/mod.rs
@@ -1,4 +1,5 @@
 pub mod about;
+pub mod demo_reaction_diffusion;
 pub mod demos;
 pub mod index;
 pub mod not_found;

--- a/crates/site/src/pages/mod.rs
+++ b/crates/site/src/pages/mod.rs
@@ -1,4 +1,5 @@
 pub mod about;
+pub mod demos;
 pub mod index;
 pub mod not_found;
 pub mod projects;

--- a/crates/site/src/route.rs
+++ b/crates/site/src/route.rs
@@ -4,10 +4,17 @@ pub enum Route {
     About,
     Projects,
     Resume,
+    Demos,
 }
 
 impl Route {
-    pub const ALL: [Route; 4] = [Route::Index, Route::About, Route::Projects, Route::Resume];
+    pub const ALL: [Route; 5] = [
+        Route::Index,
+        Route::About,
+        Route::Projects,
+        Route::Resume,
+        Route::Demos,
+    ];
 
     pub fn path(&self) -> &'static str {
         match self {
@@ -15,6 +22,7 @@ impl Route {
             Route::About => "/about/",
             Route::Projects => "/projects/",
             Route::Resume => "/resume/",
+            Route::Demos => "/demos/",
         }
     }
 
@@ -24,6 +32,7 @@ impl Route {
             Route::About => "about/index.html",
             Route::Projects => "projects/index.html",
             Route::Resume => "resume/index.html",
+            Route::Demos => "demos/index.html",
         }
     }
 
@@ -33,6 +42,7 @@ impl Route {
             Route::About => "About",
             Route::Projects => "Projects",
             Route::Resume => "Resume",
+            Route::Demos => "Demos",
         }
     }
 }
@@ -43,7 +53,7 @@ mod tests {
 
     #[test]
     fn every_route_has_a_rooted_path_and_html_output() {
-        assert_eq!(Route::ALL.len(), 4, "Demos must not exist until bucket 4");
+        assert_eq!(Route::ALL.len(), 5);
         for r in Route::ALL {
             assert!(r.path().starts_with('/'), "{:?} path must be rooted", r);
             assert!(r.output_path().ends_with(".html"), "{:?} bad output", r);
@@ -57,5 +67,12 @@ mod tests {
         assert_eq!(Route::Index.output_path(), "index.html");
         assert_eq!(Route::About.path(), "/about/");
         assert_eq!(Route::About.output_path(), "about/index.html");
+    }
+
+    #[test]
+    fn demos_is_routed() {
+        assert_eq!(Route::Demos.path(), "/demos/");
+        assert_eq!(Route::Demos.output_path(), "demos/index.html");
+        assert_eq!(Route::Demos.label(), "Demos");
     }
 }

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -200,6 +200,25 @@ h2 {{ font-size: 24px; letter-spacing: -0.02em; font-weight: 600; }}
     transition-duration: 0.01ms !important;
   }}
 }}
+
+.rd-canvas {{
+  width: 100%;
+  max-width: 660px;
+  aspect-ratio: 220 / 140;
+  display: block;
+  border: 1px solid var(--rule);
+  image-rendering: pixelated;
+  cursor: crosshair;
+  touch-action: none;
+  margin: calc(var(--space) * 3) 0;
+}}
+.rd-controls {{
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space);
+  align-items: center;
+  max-width: 660px;
+}}
 "#,
         light = tokens(LIGHT),
         dark = tokens(DARK),

--- a/docs/superpowers/plans/2026-08-12-bucket-4-reaction-diffusion-demo.md
+++ b/docs/superpowers/plans/2026-08-12-bucket-4-reaction-diffusion-demo.md
@@ -1,0 +1,1084 @@
+# Bucket 4: Reaction-Diffusion WASM Demo — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first WebAssembly on paul-maxwell.com — an interactive Gray-Scott reaction-diffusion simulation running at 60fps on a canvas, loaded only on its own page.
+
+**Architecture:** The simulation is a pure Rust crate with no WebAssembly dependency, so the physics is unit-tested natively with `cargo test` on the host. A thin `#[wasm_bindgen]` wrapper exposes it to the browser, and a small hand-written JS module loads the wasm and drives the animation loop. The generator gains a `Demos` route and one demo page; every other page ships zero WebAssembly.
+
+**Tech Stack:** Rust 1.92, `wasm-bindgen` 0.2.127, `js-sys` 0.3.104, `web-sys` 0.3.104, `maud` 0.27. No bundler, no npm, no framework.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **No threads.** GitHub Pages cannot set `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy`, so `SharedArrayBuffer` is unavailable and `rayon` cannot be used. The simulation must be single-threaded.
+- **No external hosts.** No CDN, no npm, no remote fonts or scripts. Everything is self-hosted.
+- **WASM loads only on the demo page.** Reading the bio, About, Projects, or Resume must download zero WebAssembly bytes. The loader is lazy and page-scoped.
+- **Zero `#[allow(dead_code)]` anywhere in the tree.** There are none today and none may be added.
+- **CI gates deploy on `cargo clippy --all-targets -- -D warnings` and `cargo test --all`.** A red build must never publish.
+- **Light is the default theme** for all visitors; dark is opt-in via `data-theme` + `localStorage`. The demo must be legible in both.
+- **The inline theme scripts use double-quoted JS deliberately** so their un-escaped tests are falsifying. Do not convert them to single quotes.
+- **`content/site.toml` prose is approved and fixed.** Do not reword existing copy.
+- **Motion is capped at 180ms and `prefers-reduced-motion` is honoured.** The demo animation must not auto-run for a visitor who has asked for reduced motion — see Task 5.
+- **Colour tokens:** light paper `#FBFAF8`, ink `#14161A`, muted `#6E7076`, rule `#E5E2DC`, accent `#A8431E`; dark paper `#0E0F11`, surface `#16181B`, ink `#E9E7E2`, muted `#94989F`, rule `#25282D`, accent `#E0764A`.
+
+**Simulation parameters** (Karl Sims' formulation, the standard reference):
+
+- Laplacian kernel: centre `-1.0`, edge-adjacent `0.2`, diagonal `0.05`
+- Diffusion rates: `dA = 1.0`, `dB = 0.5`; timestep `dt = 1.0`
+- Presets (feed `f`, kill `k`): coral `0.0545`/`0.0620`; mitosis `0.0367`/`0.0649`; solitons `0.0300`/`0.0620`; worms `0.0780`/`0.0610`
+- Grid wraps at the edges (toroidal), so there is no boundary special case
+
+**Deviation from the original spec, flagged:** spec §5.1 anticipated `crates/demos/<name>/`. This plan uses `crates/demos/reaction-diffusion/` with the simulation split into a dependency-free module, which the spec did not anticipate but which is what makes the physics testable without a headless browser.
+
+---
+
+### Task 1: The simulation core, with no WebAssembly in sight
+
+**Files:**
+- Create: `crates/demos/reaction-diffusion/Cargo.toml`, `crates/demos/reaction-diffusion/src/grayscott.rs`, `crates/demos/reaction-diffusion/src/lib.rs`
+- Modify: `Cargo.toml` (workspace members)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `grayscott::Grid` with `Grid::new(width: usize, height: usize) -> Grid`, `Grid::step(&mut self, feed: f32, kill: f32)`, `Grid::seed_rect(&mut self, cx: usize, cy: usize, half: usize)`, `Grid::reset(&mut self)`, `Grid::b_at(&self, x: usize, y: usize) -> f32`, `Grid::width()`, `Grid::height()`. Tasks 2 and 3 build on these.
+
+This task deliberately contains no `wasm-bindgen`. Keeping the physics in a plain Rust module is what lets `cargo test` verify it on the host — testing it through WebAssembly would need a headless browser and would make failures far harder to read.
+
+- [ ] **Step 1: Add the crate to the workspace**
+
+In the root `Cargo.toml`, change the members list to:
+
+```toml
+[workspace]
+members = ["crates/site", "crates/demos/reaction-diffusion"]
+resolver = "2"
+```
+
+Create `crates/demos/reaction-diffusion/Cargo.toml`:
+
+```toml
+[package]
+name = "reaction-diffusion"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.127"
+```
+
+`cdylib` produces the `.wasm`; `rlib` is what lets the host test binary link the same code.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `crates/demos/reaction-diffusion/src/grayscott.rs`:
+
+```rust
+//! Gray-Scott reaction-diffusion, using Karl Sims' formulation.
+//!
+//! Deliberately free of any WebAssembly dependency so the physics can be
+//! tested natively rather than through a headless browser.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A = 1, B = 0 everywhere is an exact fixed point: the reaction term
+    /// A·B² is zero, feed f·(1 − A) is zero, kill (k + f)·B is zero, and the
+    /// Laplacian of a uniform field is zero. If stepping perturbs it, the
+    /// update rule is wrong.
+    #[test]
+    fn the_empty_state_is_a_fixed_point() {
+        let mut g = Grid::new(16, 16);
+        for _ in 0..50 {
+            g.step(0.0545, 0.0620);
+        }
+        for y in 0..g.height() {
+            for x in 0..g.width() {
+                assert!(g.b_at(x, y).abs() < 1e-6, "B drifted at ({x},{y})");
+            }
+        }
+    }
+
+    #[test]
+    fn seeding_introduces_b_and_it_spreads() {
+        let mut g = Grid::new(32, 32);
+        g.seed_rect(16, 16, 2);
+        assert!(g.b_at(16, 16) > 0.4, "seed did not take");
+        assert_eq!(g.b_at(0, 0), 0.0, "seed leaked across the grid");
+
+        for _ in 0..200 {
+            g.step(0.0545, 0.0620);
+        }
+        let spread = (10..22)
+            .flat_map(|y| (10..22).map(move |x| (x, y)))
+            .filter(|&(x, y)| g.b_at(x, y) > 0.01)
+            .count();
+        assert!(spread > 16, "B did not diffuse outward, only {spread} cells");
+    }
+
+    #[test]
+    fn values_stay_within_bounds() {
+        let mut g = Grid::new(24, 24);
+        g.seed_rect(12, 12, 3);
+        for _ in 0..500 {
+            g.step(0.0545, 0.0620);
+        }
+        for y in 0..g.height() {
+            for x in 0..g.width() {
+                let b = g.b_at(x, y);
+                assert!((0.0..=1.0).contains(&b), "B out of range at ({x},{y}): {b}");
+                assert!(b.is_finite(), "B diverged at ({x},{y})");
+            }
+        }
+    }
+
+    #[test]
+    fn the_grid_wraps_rather_than_clamping() {
+        // Seeding at the right edge must influence the left edge, which only
+        // happens if the Laplacian is toroidal.
+        let mut g = Grid::new(16, 16);
+        g.seed_rect(15, 8, 1);
+        for _ in 0..100 {
+            g.step(0.0545, 0.0620);
+        }
+        assert!(g.b_at(0, 8) > 0.001, "no wrap-around diffusion");
+    }
+
+    #[test]
+    fn simulation_is_deterministic() {
+        let run = || {
+            let mut g = Grid::new(16, 16);
+            g.seed_rect(8, 8, 2);
+            for _ in 0..100 {
+                g.step(0.0545, 0.0620);
+            }
+            (0..16).map(|i| g.b_at(i, i)).collect::<Vec<_>>()
+        };
+        assert_eq!(run(), run(), "same input produced different output");
+    }
+
+    #[test]
+    fn reset_restores_the_initial_state() {
+        let mut g = Grid::new(16, 16);
+        g.seed_rect(8, 8, 2);
+        g.step(0.0545, 0.0620);
+        g.reset();
+        for y in 0..16 {
+            for x in 0..16 {
+                assert_eq!(g.b_at(x, y), 0.0, "reset left B behind at ({x},{y})");
+            }
+        }
+    }
+}
+```
+
+Create `crates/demos/reaction-diffusion/src/lib.rs`:
+
+```rust
+mod grayscott;
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cargo test -p reaction-diffusion`
+Expected: FAIL — `cannot find type 'Grid' in this scope`.
+
+- [ ] **Step 4: Implement the grid**
+
+Add above the `tests` module in `grayscott.rs`:
+
+```rust
+const DA: f32 = 1.0;
+const DB: f32 = 0.5;
+const DT: f32 = 1.0;
+
+/// Two chemical concentration fields on a toroidal grid.
+pub struct Grid {
+    width: usize,
+    height: usize,
+    a: Vec<f32>,
+    b: Vec<f32>,
+    a_next: Vec<f32>,
+    b_next: Vec<f32>,
+}
+
+impl Grid {
+    pub fn new(width: usize, height: usize) -> Self {
+        let n = width * height;
+        Self {
+            width,
+            height,
+            a: vec![1.0; n],
+            b: vec![0.0; n],
+            a_next: vec![1.0; n],
+            b_next: vec![0.0; n],
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    pub fn b_at(&self, x: usize, y: usize) -> f32 {
+        self.b[y * self.width + x]
+    }
+
+    pub fn reset(&mut self) {
+        self.a.fill(1.0);
+        self.b.fill(0.0);
+    }
+
+    /// Fill a square of B, the disturbance the patterns grow from.
+    pub fn seed_rect(&mut self, cx: usize, cy: usize, half: usize) {
+        for dy in -(half as isize)..=(half as isize) {
+            for dx in -(half as isize)..=(half as isize) {
+                let x = (cx as isize + dx).rem_euclid(self.width as isize) as usize;
+                let y = (cy as isize + dy).rem_euclid(self.height as isize) as usize;
+                self.b[y * self.width + x] = 1.0;
+            }
+        }
+    }
+
+    /// Weighted 3×3 Laplacian with wrap-around, per Karl Sims: centre −1,
+    /// edge-adjacent 0.2, diagonal 0.05.
+    fn laplace(&self, field: &[f32], x: usize, y: usize) -> f32 {
+        let w = self.width as isize;
+        let h = self.height as isize;
+        let at = |dx: isize, dy: isize| -> f32 {
+            let nx = (x as isize + dx).rem_euclid(w) as usize;
+            let ny = (y as isize + dy).rem_euclid(h) as usize;
+            field[ny * self.width + nx]
+        };
+        -field[y * self.width + x]
+            + 0.2 * (at(-1, 0) + at(1, 0) + at(0, -1) + at(0, 1))
+            + 0.05 * (at(-1, -1) + at(1, -1) + at(-1, 1) + at(1, 1))
+    }
+
+    pub fn step(&mut self, feed: f32, kill: f32) {
+        for y in 0..self.height {
+            for x in 0..self.width {
+                let i = y * self.width + x;
+                let a = self.a[i];
+                let b = self.b[i];
+                let abb = a * b * b;
+                self.a_next[i] =
+                    (a + (DA * self.laplace(&self.a, x, y) - abb + feed * (1.0 - a)) * DT)
+                        .clamp(0.0, 1.0);
+                self.b_next[i] =
+                    (b + (DB * self.laplace(&self.b, x, y) + abb - (kill + feed) * b) * DT)
+                        .clamp(0.0, 1.0);
+            }
+        }
+        std::mem::swap(&mut self.a, &mut self.a_next);
+        std::mem::swap(&mut self.b, &mut self.b_next);
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p reaction-diffusion`
+Expected: PASS, 6 tests.
+
+Then `cargo clippy --all-targets -- -D warnings` — expected clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/demos
+git commit -m "feat: add Gray-Scott reaction-diffusion simulation core"
+```
+
+---
+
+### Task 2: Rendering to a pixel buffer
+
+**Files:**
+- Create: `crates/demos/reaction-diffusion/src/render.rs`
+- Modify: `crates/demos/reaction-diffusion/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `grayscott::Grid` (Task 1).
+- Produces: `render::Palette` (enum with variants `Light`, `Dark`), `render::paint(grid: &Grid, palette: Palette, out: &mut [u8])`. Task 3 calls `paint` into a buffer it shares with JavaScript.
+
+The buffer is RGBA, four bytes per cell, matching the browser's `ImageData` layout so the JS side can hand it straight to the canvas with no per-pixel work.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/demos/reaction-diffusion/src/render.rs`:
+
+```rust
+use crate::grayscott::Grid;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paint_fills_every_pixel_opaque() {
+        let g = Grid::new(8, 8);
+        let mut buf = vec![0u8; 8 * 8 * 4];
+        paint(&g, Palette::Light, &mut buf);
+        for px in buf.chunks_exact(4) {
+            assert_eq!(px[3], 255, "alpha must be opaque");
+        }
+    }
+
+    #[test]
+    fn empty_grid_paints_the_background_colour() {
+        let g = Grid::new(4, 4);
+        let mut buf = vec![0u8; 4 * 4 * 4];
+        paint(&g, Palette::Light, &mut buf);
+        // B = 0 everywhere, so every pixel is the light paper colour #FBFAF8.
+        assert_eq!(&buf[0..3], &[0xFB, 0xFA, 0xF8]);
+    }
+
+    #[test]
+    fn seeded_cells_differ_from_background() {
+        let mut g = Grid::new(8, 8);
+        g.seed_rect(4, 4, 0);
+        let mut buf = vec![0u8; 8 * 8 * 4];
+        paint(&g, Palette::Light, &mut buf);
+        let bg = &buf[0..3];
+        let seeded = &buf[(4 * 8 + 4) * 4..(4 * 8 + 4) * 4 + 3];
+        assert_ne!(bg, seeded, "seeded cell rendered identically to background");
+    }
+
+    #[test]
+    fn palettes_differ() {
+        let g = Grid::new(4, 4);
+        let mut light = vec![0u8; 4 * 4 * 4];
+        let mut dark = vec![0u8; 4 * 4 * 4];
+        paint(&g, Palette::Light, &mut light);
+        paint(&g, Palette::Dark, &mut dark);
+        assert_ne!(light, dark, "light and dark rendered identically");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p reaction-diffusion render`
+Expected: FAIL — `cannot find function 'paint'`.
+
+- [ ] **Step 3: Implement rendering**
+
+Add above the `tests` module in `render.rs`:
+
+```rust
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Palette {
+    Light,
+    Dark,
+}
+
+impl Palette {
+    /// (background, foreground) as RGB, taken from the site's design tokens
+    /// so the demo belongs to the page rather than sitting on it.
+    fn ends(self) -> ([u8; 3], [u8; 3]) {
+        match self {
+            // paper #FBFAF8 → accent #A8431E
+            Palette::Light => ([0xFB, 0xFA, 0xF8], [0xA8, 0x43, 0x1E]),
+            // paper #0E0F11 → accent #E0764A
+            Palette::Dark => ([0x0E, 0x0F, 0x11], [0xE0, 0x76, 0x4A]),
+        }
+    }
+}
+
+fn lerp(a: u8, b: u8, t: f32) -> u8 {
+    (f32::from(a) + (f32::from(b) - f32::from(a)) * t).round() as u8
+}
+
+/// Paint B concentration into an RGBA buffer laid out for `ImageData`.
+pub fn paint(grid: &Grid, palette: Palette, out: &mut [u8]) {
+    let (bg, fg) = palette.ends();
+    for y in 0..grid.height() {
+        for x in 0..grid.width() {
+            // B rarely exceeds ~0.4, so scale before clamping or the image
+            // stays nearly background-coloured.
+            let t = (grid.b_at(x, y) * 2.5).clamp(0.0, 1.0);
+            let i = (y * grid.width() + x) * 4;
+            out[i] = lerp(bg[0], fg[0], t);
+            out[i + 1] = lerp(bg[1], fg[1], t);
+            out[i + 2] = lerp(bg[2], fg[2], t);
+            out[i + 3] = 255;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Register the module and run the tests**
+
+`crates/demos/reaction-diffusion/src/lib.rs`:
+
+```rust
+mod grayscott;
+mod render;
+```
+
+Run: `cargo test -p reaction-diffusion` — expected PASS, 10 tests.
+Run: `cargo clippy --all-targets -- -D warnings` — expected clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/demos/reaction-diffusion/src
+git commit -m "feat: render reaction-diffusion state into an RGBA buffer"
+```
+
+---
+
+### Task 3: The WebAssembly boundary and build script
+
+**Files:**
+- Modify: `crates/demos/reaction-diffusion/src/lib.rs`
+- Create: `scripts/build-wasm.sh`
+
+**Interfaces:**
+- Consumes: `grayscott::Grid`, `render::{paint, Palette}`.
+- Produces: a `Simulation` type exported to JavaScript with `new Simulation(width, height)`, `.step(feed, kill, substeps)`, `.render(dark)`, `.seed(x, y, half)`, `.reset()`, `.pixels_ptr()`, `.pixels_len()`, `.width()`, `.height()`. Task 5's JS module calls exactly these.
+- Produces: `scripts/build-wasm.sh`, which Task 7 calls from CI.
+
+- [ ] **Step 1: Install the target and CLI locally**
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install wasm-bindgen-cli --version 0.2.127
+```
+
+The CLI version must match the `wasm-bindgen` crate version exactly — a mismatch produces a confusing "schema version mismatch" error at build time rather than at runtime.
+
+- [ ] **Step 2: Write the wasm wrapper**
+
+Replace `crates/demos/reaction-diffusion/src/lib.rs`:
+
+```rust
+mod grayscott;
+mod render;
+
+use grayscott::Grid;
+use render::{paint, Palette};
+use wasm_bindgen::prelude::*;
+
+/// The simulation as JavaScript sees it.
+///
+/// Pixels live in wasm linear memory; JS reads them through a view rather
+/// than copying, so a frame costs one `putImageData` and no marshalling.
+#[wasm_bindgen]
+pub struct Simulation {
+    grid: Grid,
+    pixels: Vec<u8>,
+}
+
+#[wasm_bindgen]
+impl Simulation {
+    #[wasm_bindgen(constructor)]
+    pub fn new(width: usize, height: usize) -> Simulation {
+        Simulation {
+            grid: Grid::new(width, height),
+            pixels: vec![0; width * height * 4],
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        self.grid.width()
+    }
+
+    pub fn height(&self) -> usize {
+        self.grid.height()
+    }
+
+    /// Advance `substeps` iterations. More substeps per frame means faster
+    /// pattern evolution without a higher frame rate.
+    pub fn step(&mut self, feed: f32, kill: f32, substeps: u32) {
+        for _ in 0..substeps {
+            self.grid.step(feed, kill);
+        }
+    }
+
+    pub fn render(&mut self, dark: bool) {
+        let palette = if dark { Palette::Dark } else { Palette::Light };
+        paint(&self.grid, palette, &mut self.pixels);
+    }
+
+    pub fn seed(&mut self, x: usize, y: usize, half: usize) {
+        self.grid.seed_rect(x, y, half);
+    }
+
+    pub fn reset(&mut self) {
+        self.grid.reset();
+    }
+
+    pub fn pixels_ptr(&self) -> *const u8 {
+        self.pixels.as_ptr()
+    }
+
+    pub fn pixels_len(&self) -> usize {
+        self.pixels.len()
+    }
+}
+```
+
+- [ ] **Step 3: Write the build script**
+
+Create `scripts/build-wasm.sh` and `chmod +x` it:
+
+```bash
+#!/bin/bash
+# Builds the reaction-diffusion demo to WebAssembly and emits the JS bindings.
+# Run before `cargo run -p site` so the generator can copy the artifacts.
+set -euo pipefail
+
+OUT=static/demos/reaction-diffusion
+
+cargo build -p reaction-diffusion --target wasm32-unknown-unknown --release
+
+mkdir -p "$OUT"
+wasm-bindgen \
+  --target web \
+  --no-typescript \
+  --out-dir "$OUT" \
+  target/wasm32-unknown-unknown/release/reaction_diffusion.wasm
+
+echo "wasm artifacts in $OUT:"
+ls -la "$OUT"
+```
+
+`--target web` emits an ES module usable directly from a `<script type="module">` with no bundler. `--no-typescript` skips `.d.ts` files we have no use for.
+
+Output lands in `static/`, which the site generator already copies wholesale into `dist/` — so the wasm needs no special handling in the build.
+
+- [ ] **Step 4: Build and verify**
+
+```bash
+./scripts/build-wasm.sh
+ls -la static/demos/reaction-diffusion/
+du -h static/demos/reaction-diffusion/reaction_diffusion_bg.wasm
+```
+
+Expected: `reaction_diffusion.js` and `reaction_diffusion_bg.wasm` exist. Record the `.wasm` size in your report — it is the number that decides whether this was worth shipping.
+
+- [ ] **Step 5: Keep build output out of git**
+
+The generated wasm and JS are build artifacts, not source. Append to `.gitignore`:
+
+```
+/static/demos/reaction-diffusion/
+```
+
+Verify with `git status --short` that nothing under that path is staged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/demos/reaction-diffusion/src/lib.rs scripts/build-wasm.sh .gitignore
+git commit -m "feat: expose the simulation to WebAssembly with a build script"
+```
+
+---
+
+### Task 4: The Demos route
+
+**Files:**
+- Modify: `crates/site/src/route.rs`, `crates/site/src/components/rail.rs`, `crates/site/src/checks.rs`, `crates/site/src/build.rs`
+- Create: `crates/site/src/pages/demos.rs`
+- Modify: `crates/site/src/pages/mod.rs`
+
+**Interfaces:**
+- Consumes: `Route`, `shell::layout`, `content::Site`.
+- Produces: `Route::Demos` (fifth variant, `path()` = `/demos/`, `output_path()` = `demos/index.html`, `label()` = `"Demos"`), and `pages::demos::render(site: &Site) -> Markup`.
+
+This is where the bucket-1 constraint "Demos must not exist" is deliberately lifted. Four places assert it today and all four must change:
+
+- `route.rs:10` — `ALL: [Route; 4]`
+- `route.rs:46` — `assert_eq!(Route::ALL.len(), 4, "Demos must not exist until bucket 4")`
+- `rail.rs:69` — `assert!(!out.contains("Demos"), "Demos must not be linked in bucket 1")`
+- `checks.rs:129` — uses `/demos/` as its *dead link* fixture
+
+That last one is subtle. The test scaffolds its own temp directory, so `/demos/` is still genuinely absent there and the test still passes — but using a path that now exists on the real site as the example of a broken link is actively misleading. Change the fixture to `/nonexistent-page/` and keep the assertion identical.
+
+- [ ] **Step 1: Update the route tests**
+
+In `route.rs`, change the count assertion to:
+
+```rust
+        assert_eq!(Route::ALL.len(), 5);
+```
+
+and add to the same test module:
+
+```rust
+    #[test]
+    fn demos_is_routed() {
+        assert_eq!(Route::Demos.path(), "/demos/");
+        assert_eq!(Route::Demos.output_path(), "demos/index.html");
+        assert_eq!(Route::Demos.label(), "Demos");
+    }
+```
+
+In `rail.rs`, replace the `!out.contains("Demos")` assertion with:
+
+```rust
+        assert!(out.contains("Demos"), "Demos must be linked from bucket 4 on");
+```
+
+In `checks.rs`, change the dead-link fixture from `/demos/` to `/nonexistent-page/` in both the scaffolded HTML and the assertion that the error names it.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p site`
+Expected: FAIL — no `Route::Demos` variant, and the rail assertion fails.
+
+- [ ] **Step 3: Add the route**
+
+In `route.rs`, add `Demos` to the enum after `Resume`, extend `ALL` to `[Route; 5]` including `Route::Demos`, and add match arms: `path()` → `"/demos/"`, `output_path()` → `"demos/index.html"`, `label()` → `"Demos"`.
+
+- [ ] **Step 4: Write the failing page test**
+
+Create `crates/site/src/pages/demos.rs`:
+
+```rust
+use crate::components::shell;
+use crate::content::Site;
+use crate::route::Route;
+use maud::{html, Markup};
+
+/// Path of the reaction-diffusion demo page. Task 5 renders it.
+pub const REACTION_DIFFUSION: &str = "/demos/reaction-diffusion/";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demos_index_links_to_the_reaction_diffusion_demo() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(REACTION_DIFFUSION), "demo link missing");
+        assert!(out.contains("Reaction-Diffusion"));
+        assert!(out.contains(r#"href="/demos/" aria-current="page""#));
+    }
+}
+```
+
+- [ ] **Step 5: Run it to verify it fails, then implement**
+
+Run: `cargo test -p site demos` — expected FAIL, `cannot find function 'render'`.
+
+Add above the `tests` module:
+
+```rust
+pub fn render(site: &Site) -> Markup {
+    let main = html! {
+        h1 { "Demos" }
+        p .prose { "Small things built in Rust, compiled to WebAssembly, running in your browser." }
+        div .section-head {
+            span .mono { "Demos" }
+            span .mono { "01" }
+        }
+        div .item {
+            div {
+                h3 { a href=(REACTION_DIFFUSION) { "Reaction-Diffusion" } }
+                p { "A Gray-Scott simulation: two chemicals, one feeding on the other, painting patterns that look uncannily biological. Every pixel is computed in Rust, sixty times a second." }
+            }
+            div .mono .year { "2026" }
+        }
+    };
+    shell::layout(site, Route::Demos, "Demos", main)
+}
+```
+
+- [ ] **Step 6: Wire the route into the build**
+
+Register `pub mod demos;` in `pages/mod.rs`, and add the `Route::Demos => pages::demos::render(&site)` arm to the match in `build.rs`.
+
+Run: `cargo test -p site` and `cargo clippy --all-targets -- -D warnings` — both expected clean. Then `cargo run -p site -- --strict` and confirm `dist/demos/index.html` exists and `dist/sitemap.xml` now lists five URLs.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/site/src
+git commit -m "feat: add the Demos route and index page"
+```
+
+---
+
+### Task 5: The demo page and its loader
+
+**Files:**
+- Create: `crates/site/src/pages/demo_reaction_diffusion.rs`, `static/demos/loader.js`
+- Modify: `crates/site/src/pages/mod.rs`, `crates/site/src/build.rs`, `crates/site/src/theme.rs`
+
+**Interfaces:**
+- Consumes: `Route::Demos`, `shell::layout`, and the `Simulation` API from Task 3.
+- Produces: `pages::demo_reaction_diffusion::render(site: &Site) -> Markup`, written to `demos/reaction-diffusion/index.html`.
+
+The demo page is not a `Route` variant — `Route::ALL` drives the nav, and a second Demos-family entry there would duplicate the nav item. It is written directly, exactly as the 404 page is.
+
+- [ ] **Step 1: Write the loader**
+
+Create `static/demos/loader.js`:
+
+```js
+// Lazy loader for the reaction-diffusion demo. Only this page imports it,
+// so no other page on the site downloads any WebAssembly.
+import init, { Simulation } from "./reaction-diffusion/reaction_diffusion.js";
+
+const PRESETS = {
+  coral:     { feed: 0.0545, kill: 0.0620 },
+  mitosis:   { feed: 0.0367, kill: 0.0649 },
+  solitons:  { feed: 0.0300, kill: 0.0620 },
+  worms:     { feed: 0.0780, kill: 0.0610 },
+};
+
+async function main() {
+  const canvas = document.getElementById("rd-canvas");
+  const status = document.getElementById("rd-status");
+  if (!canvas) return;
+
+  const wasm = await init();
+  const sim = new Simulation(220, 140);
+  const w = sim.width(), h = sim.height();
+  canvas.width = w;
+  canvas.height = h;
+
+  const ctx = canvas.getContext("2d");
+  const image = ctx.createImageData(w, h);
+
+  let preset = PRESETS.coral;
+  let running = false;
+  let frames = 0, fpsAt = performance.now();
+
+  const isDark = () => document.documentElement.dataset.theme === "dark";
+
+  function seedCentre() {
+    sim.reset();
+    for (let i = 0; i < 12; i++) {
+      const x = Math.floor(w / 2 + (Math.random() - 0.5) * 40);
+      const y = Math.floor(h / 2 + (Math.random() - 0.5) * 40);
+      sim.seed(x, y, 3);
+    }
+  }
+
+  function draw() {
+    sim.render(isDark());
+    const px = new Uint8ClampedArray(wasm.memory.buffer, sim.pixels_ptr(), sim.pixels_len());
+    image.data.set(px);
+    ctx.putImageData(image, 0, 0);
+  }
+
+  function frame() {
+    if (!running) return;
+    sim.step(preset.feed, preset.kill, 8);
+    draw();
+    frames++;
+    const now = performance.now();
+    if (now - fpsAt >= 1000) {
+      status.textContent = frames + " fps";
+      frames = 0;
+      fpsAt = now;
+    }
+    requestAnimationFrame(frame);
+  }
+
+  function start() {
+    if (running) return;
+    running = true;
+    status.textContent = "running";
+    requestAnimationFrame(frame);
+  }
+
+  function stop() {
+    running = false;
+    status.textContent = "paused";
+  }
+
+  canvas.addEventListener("pointerdown", (e) => {
+    const r = canvas.getBoundingClientRect();
+    const x = Math.floor((e.clientX - r.left) / r.width * w);
+    const y = Math.floor((e.clientY - r.top) / r.height * h);
+    sim.seed(x, y, 4);
+    if (!running) draw();
+  });
+
+  document.getElementById("rd-toggle").addEventListener("click", () => {
+    running ? stop() : start();
+  });
+  document.getElementById("rd-reset").addEventListener("click", () => {
+    seedCentre();
+    draw();
+  });
+  document.querySelectorAll("[data-preset]").forEach((b) => {
+    b.addEventListener("click", () => {
+      preset = PRESETS[b.dataset.preset];
+      seedCentre();
+      if (!running) draw();
+    });
+  });
+
+  seedCentre();
+  draw();
+
+  // Respect a reduced-motion preference: render one frame and wait to be
+  // asked rather than animating unbidden.
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    status.textContent = "paused — reduced motion";
+  } else {
+    start();
+  }
+}
+
+main();
+```
+
+- [ ] **Step 2: Write the failing page test**
+
+Create `crates/site/src/pages/demo_reaction_diffusion.rs`:
+
+```rust
+use crate::components::shell;
+use crate::content::Site;
+use crate::route::Route;
+use maud::{html, Markup};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demo_page_has_a_canvas_and_loads_the_module_lazily() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(r#"id="rd-canvas""#), "canvas missing");
+        assert!(out.contains(r#"type="module""#), "module script missing");
+        assert!(out.contains("/demos/loader.js"), "loader not referenced");
+        assert!(out.contains(r#"data-preset="coral""#), "presets missing");
+        assert!(out.contains("noscript"), "no fallback for JS-disabled visitors");
+    }
+
+    #[test]
+    fn demo_page_marks_demos_as_the_current_nav_item() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(r#"href="/demos/" aria-current="page""#));
+    }
+}
+```
+
+- [ ] **Step 3: Run it to verify it fails, then implement**
+
+Run: `cargo test -p site demo_page` — expected FAIL.
+
+Add above the `tests` module:
+
+```rust
+pub fn render(site: &Site) -> Markup {
+    let main = html! {
+        h1 { "Reaction-Diffusion" }
+        p .prose {
+            "Two chemicals diffuse across a grid at different rates; one converts the other on contact. "
+            "That single rule, iterated, produces patterns that look like coral, cell division, or fingerprints. "
+            "The whole simulation runs in Rust compiled to WebAssembly — click the canvas to disturb it."
+        }
+
+        canvas #rd-canvas .rd-canvas {}
+
+        div .rd-controls {
+            button #rd-toggle .theme-toggle type="button" { "Pause" }
+            button #rd-reset .theme-toggle type="button" { "Reset" }
+            @for (id, label) in [("coral", "Coral"), ("mitosis", "Mitosis"), ("solitons", "Solitons"), ("worms", "Worms")] {
+                button .theme-toggle type="button" data-preset=(id) { (label) }
+            }
+            span #rd-status .mono { "loading" }
+        }
+
+        noscript {
+            p .prose { "This demo needs JavaScript and WebAssembly. The rest of the site works without either." }
+        }
+
+        script type="module" src="/demos/loader.js" {}
+    };
+    shell::layout(site, Route::Demos, "Reaction-Diffusion", main)
+}
+```
+
+- [ ] **Step 4: Style the canvas**
+
+In `theme::stylesheet()`, add inside the `format!` raw string (remember: literal braces doubled):
+
+```css
+.rd-canvas {{
+  width: 100%;
+  max-width: 660px;
+  aspect-ratio: 220 / 140;
+  display: block;
+  border: 1px solid var(--rule);
+  image-rendering: pixelated;
+  cursor: crosshair;
+  touch-action: none;
+  margin: calc(var(--space) * 3) 0;
+}}
+.rd-controls {{
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space);
+  align-items: center;
+  max-width: 660px;
+}}
+```
+
+`image-rendering: pixelated` keeps the upscaled grid crisp rather than blurred, and `touch-action: none` stops a drag on the canvas from scrolling the page on mobile.
+
+- [ ] **Step 5: Write the page in the build**
+
+In `build.rs`, alongside the existing `404.html` write, add a write of `pages::demo_reaction_diffusion::render(&site)` to `demos/reaction-diffusion/index.html`. Register `pub mod demo_reaction_diffusion;` in `pages/mod.rs`.
+
+Add a build test asserting `dist/demos/reaction-diffusion/index.html` exists, and that `sitemap.xml` does **not** contain `reaction-diffusion` — the demo page is not a `Route`, so it should not appear there.
+
+- [ ] **Step 6: Verify end to end**
+
+```bash
+./scripts/build-wasm.sh
+cargo test --all
+cargo clippy --all-targets -- -D warnings
+cargo run -p site -- --strict
+python3 -m http.server 8137 -d dist
+```
+
+Open `http://localhost:8137/demos/reaction-diffusion/`. Confirm: patterns appear and evolve; clicking the canvas seeds new growth; the preset buttons change the pattern; pause/reset work; the fps readout is sensible; and toggling the site theme changes the demo's colours on the next frame.
+
+Then confirm the isolation constraint — no other page pulls wasm:
+
+```bash
+grep -l 'loader.js' dist/**/*.html
+```
+
+Expected: only `dist/demos/reaction-diffusion/index.html`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/site/src static/demos/loader.js
+git commit -m "feat: add the reaction-diffusion demo page and lazy loader"
+```
+
+---
+
+### Task 6: Measure it before claiming it
+
+**Files:**
+- Create: `docs/superpowers/wasm-benchmark.md`
+
+**Interfaces:**
+- Consumes: the built demo.
+- Produces: a written measurement. No code ships from this task unless the numbers justify it.
+
+The pitch for this demo is that WebAssembly does work JavaScript would struggle with. That is an assumption. A modern JIT on a tight loop over a typed array can come closer than people expect, and if it does, a side-by-side comparison would undercut the demo rather than sell it. Measure first, decide second.
+
+- [ ] **Step 1: Write a JavaScript reference implementation**
+
+Create a scratch file (not committed to `static/`) implementing the identical Gray-Scott update over `Float32Array`s — same kernel weights, same constants, same grid size, same substep count as the Rust version. Correctness matters: an accidentally cheaper JS version would produce a flattering, meaningless result.
+
+- [ ] **Step 2: Time both**
+
+In the browser console on the demo page, time 300 substeps of each at 220×140, five runs, and record the median milliseconds per substep for both. Use `performance.now()`, and discard the first run — JIT warm-up would otherwise make JS look worse than it is.
+
+- [ ] **Step 3: Record the result and decide**
+
+Write `docs/superpowers/wasm-benchmark.md` with: browser and version, machine, grid size, substep count, the raw medians, and the ratio.
+
+Then apply this rule, and state which branch you took:
+
+- **Ratio ≥ 2×:** the claim holds. Note that a comparison toggle would be a worthwhile follow-up, and record the number — a specific "3.4× faster than the equivalent JavaScript" is a far better portfolio line than a vague assertion.
+- **Ratio < 2×:** the claim does not hold on this workload. Say so plainly in the document, and do **not** build a comparison UI that would advertise a weak result. The demo still stands on its own as an interactive simulation; it just should not be sold on a speed claim.
+
+Do not adjust the JS implementation to make the ratio look better. A benchmark you tuned toward a conclusion is worth nothing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/wasm-benchmark.md
+git commit -m "docs: measure WebAssembly against a JavaScript reference"
+```
+
+---
+
+### Task 7: CI builds the WebAssembly
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml`
+
+**Interfaces:**
+- Consumes: `scripts/build-wasm.sh`.
+- Produces: a deployment including the wasm artifacts.
+
+The wasm is gitignored build output, so without this task CI would publish a demo page whose module 404s. Nothing in the existing test suite would catch that, because the artifacts exist locally.
+
+- [ ] **Step 1: Add the wasm toolchain to the build job**
+
+In `.github/workflows/deploy.yml`, change the toolchain step to install the target:
+
+```yaml
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+        targets: wasm32-unknown-unknown
+```
+
+- [ ] **Step 2: Install the CLI and build the wasm**
+
+After the `Swatinem/rust-cache@v2` step and before `Build site`, add:
+
+```yaml
+    - name: Install wasm-bindgen-cli
+      run: cargo install wasm-bindgen-cli --version 0.2.127 --locked
+
+    - name: Build WebAssembly
+      run: ./scripts/build-wasm.sh
+```
+
+The version must match the `wasm-bindgen` dependency exactly. `--locked` keeps a transitive update from silently changing the tool mid-flight. The rust-cache step covers `~/.cargo/bin`, so the install is paid once and restored thereafter.
+
+Order matters: this must run before `Build site`, because the generator copies `static/` into `dist/` and the artifacts have to exist by then.
+
+- [ ] **Step 3: Fail the build if the artifacts are missing**
+
+Add immediately after `Build site`:
+
+```yaml
+    - name: Verify wasm shipped
+      run: |
+        test -f dist/demos/reaction-diffusion/reaction_diffusion_bg.wasm
+        test -f dist/demos/reaction-diffusion/reaction_diffusion.js
+        ls -la dist/demos/reaction-diffusion/
+```
+
+This is the guard that makes the failure loud. A missing artifact would otherwise produce a page that looks fine to every test and is broken for every visitor.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci: build WebAssembly before the site and verify it ships"
+```
+
+---
+
+## Definition of Done
+
+- The demo runs at `/demos/reaction-diffusion/` on the live site, animating smoothly, responding to clicks and preset changes.
+- `Demos` appears in the nav; `/demos/` lists the demo; the demo page itself is not in `sitemap.xml`.
+- No page other than the demo downloads any WebAssembly.
+- With JavaScript disabled, the demo page renders its explanation and a `noscript` note; every other page is unaffected.
+- A visitor with `prefers-reduced-motion` gets a still first frame rather than an unbidden animation.
+- The demo's colours follow the site theme in both light and dark.
+- CI builds the wasm, verifies both artifacts land in `dist/`, and fails the build if either is missing.
+- `cargo test --all` and `cargo clippy --all-targets -- -D warnings` pass; zero `#[allow(dead_code)]` in the tree.
+- `docs/superpowers/wasm-benchmark.md` records a real measurement and the decision it drove.

--- a/docs/superpowers/wasm-benchmark.md
+++ b/docs/superpowers/wasm-benchmark.md
@@ -1,0 +1,194 @@
+# WebAssembly vs. JavaScript: measuring the reaction-diffusion demo
+
+The demo's pitch is that WebAssembly does work JavaScript would struggle
+with. That is an assumption, not a given — a modern JIT on a tight loop over
+`Float32Array`s can come closer than people expect. This document measures
+it directly, before any comparison claim ships.
+
+## Setup
+
+- **Browser**: Headless Chrome 151.0.7922.109 (V8 15.1.206.16), launched
+  with `--headless=new` against an isolated, freshly created
+  `--user-data-dir` (not the user's real profile), driven via the Chrome
+  DevTools Protocol (`Runtime.evaluate`) — the same approach Task 5 used to
+  verify the demo end-to-end.
+- **Machine**: Apple M4, macOS 26.6.1 (build 25G76), 10 cores.
+- **Page**: the built demo served from `dist/demos/reaction-diffusion/` via
+  a local `python3 -m http.server` on `localhost:8137`.
+- **Grid size**: 220×140 (same as the live demo).
+- **Substep count**: 300 per timed call, matching `Simulation::step`'s own
+  substep-looping semantics (one call runs the full batch internally, same
+  as the JS reference's `stepN`).
+- **Preset**: coral (`feed = 0.0545`, `kill = 0.0620`), the demo's default.
+- **Wasm binary size**: 27,640 bytes raw (measured directly, matches the
+  brief's stated figure exactly), 12,318 bytes gzipped (`gzip -9 -n`,
+  content only, no filename/mtime header). This is for context on load
+  cost — not part of the runtime-speed question this document answers. The
+  brief cited 12,350 gzipped; the ~30-byte difference is consistent with
+  gzip header metadata (e.g. an embedded filename) rather than a different
+  file, and doesn't affect anything below.
+
+## The JavaScript reference
+
+Written from scratch as scratch code at
+`/private/tmp/.../scratchpad/js-reference.js` (session-local scratchpad, not
+committed, not under `static/`, not referenced by any page). It is a
+line-for-line port of `crates/demos/reaction-diffusion/src/grayscott.rs`:
+same kernel weights (centre `-1.0`, edge-adjacent `0.2`, diagonal `0.05`),
+same constants (`DA = 1.0`, `DB = 0.5`, `DT = 1.0`), same toroidal wrap via
+double-modulo (JS has no `rem_euclid`), same double-buffered `a`/`b`/`aNext`/
+`bNext` as `Float32Array`s, same `[0, 1]` clamp. No `Array` of objects, no
+hand-tuning, no attempt to make either implementation look better — the
+per-cell 3×3 Laplacian is a small closure called from the hot loop in both
+languages, mirroring the Rust source's own `at` closure rather than being
+manually unrolled for speed in either direction.
+
+## Equivalence verification
+
+Three independent checks, run before any timing:
+
+1. **Closed-form pin (JS-only, mirrors the Rust unit tests).** A single
+   seeded cell (`seed_rect(4, 4, 0)` on an 8×8 grid) stepped once with
+   `A = 1, B = 0` everywhere else has closed-form neighbour values,
+   independent of the reaction/kill terms (both are zero when the
+   neighbour's own B is zero). The Rust test `laplacian_weights_are_exact`
+   asserts an edge-adjacent neighbour of `0.1` and a diagonal neighbour of
+   `0.025`. The JS port reproduced:
+   - edge-adjacent: `0.10000000149011612`
+   - diagonal: `0.02500000037252903`
+
+   Both match `0.1` and `0.025` to `f32` precision (the trailing digits are
+   exactly `f32`'s representation error for these values). This pins `DB`,
+   the edge weight, and the diagonal weight in the JS port independent of
+   any comparison against the WASM build.
+2. **Wrap-around pin (JS-only, mirrors `wrap_is_immediate_across_the_edge`).**
+   A cell seeded at the right edge of a 16×16 grid (`seed_rect(15, 8, 0)`),
+   stepped once, produced `0.10000000149011612` at its wrap-around neighbour
+   `(0, 8)` — confirming the toroidal wrap is immediate, not clamping.
+3. **Cross-implementation comparison against the real WASM build.** A fresh
+   `Simulation` (WASM) and a fresh `JSGrid` (JS reference) at 220×140 were
+   seeded identically at five fixed points (`[110,70,3]`, `[60,40,2]`,
+   `[160,100,4]`, `[30,110,2]`, `[200,20,3]`) and stepped through checkpoints
+   at 1, 5, 10, 25, and 50 total steps with the coral preset. At each
+   checkpoint, the WASM field was rendered via `Simulation.render()` (the
+   only public accessor for the field — it exposes the B channel, quantized
+   to `u8`) and compared byte-for-byte against a JS port of `render.rs`'s
+   `paint()` applied to the JS field. Result: **`maxDiff = 0` at every
+   checkpoint** (all 30,800 pixels × 4 channels, at all five checkpoints) —
+   the two implementations are pixel-identical, not merely close. This is
+   strong evidence of true equivalence: a reaction-diffusion system is
+   sensitive enough that a wrong constant or kernel weight would show
+   visible divergence well before 50 steps.
+
+Equivalence is verified. The timing comparison below is against a genuinely
+equivalent implementation.
+
+## Method
+
+For each implementation: 5 runs of 300 substeps at 220×140, timed with
+`performance.now()` around a single call that loops all 300 substeps
+internally (`Simulation.step(feed, kill, 300)` for WASM,
+`JSGrid.stepN(feed, kill, 300)` for JS). Runs were interleaved (wasm, js,
+wasm, js, ...) across the same page load to spread any thermal/scheduling
+drift evenly across both implementations rather than let it fall unevenly on
+whichever ran second. The first run of each implementation was discarded to
+exclude V8 JIT warm-up (WASM is ahead-of-time compiled and has no analogous
+warm-up cost, but was measured under the identical discard-first protocol
+for symmetry). Median taken over the remaining four runs.
+
+## Raw results (primary run)
+
+**WASM** (ms per 300-substep call):
+
+| run | ms |
+|---|---|
+| 1 (discarded — warm-up) | 101.00 |
+| 2 | 97.40 |
+| 3 | 97.90 |
+| 4 | 98.20 |
+| 5 | 98.60 |
+
+Median of runs 2–5: **98.05 ms** (0.327 ms/substep)
+
+**JavaScript** (ms per 300-substep call):
+
+| run | ms |
+|---|---|
+| 1 (discarded — warm-up) | 194.10 |
+| 2 | 193.20 |
+| 3 | 190.20 |
+| 4 | 188.00 |
+| 5 | 188.80 |
+
+Median of runs 2–5: **189.50 ms** (0.632 ms/substep)
+
+**Ratio (JS median ÷ WASM median): 1.93×**
+
+### Stability check
+
+The full 5-run protocol was repeated three additional times (fresh page
+loads) to confirm the primary run wasn't a fluke:
+
+| run set | WASM raw (ms) | JS raw (ms) |
+|---|---|---|
+| check 1 | 98.8, 100.5, 99.7, 100.2, 98.6 | 190.2, 190.5, 191.1, 190.8, 190.6 |
+| check 2 | 100.6, 100.5, 102.2, 97.5, 98.1 | 191.4, 191.6, 192.4, 193.1, 191.8 |
+| check 3 | 99.0, 99.6, 99.4, 98.1, 99.6 | 191.0, 190.7, 191.7, 190.4, 190.9 |
+
+All three land in the same ~98–100 ms (WASM) / ~190–193 ms (JS) band as the
+primary run, giving a ratio consistently in the **1.9×–1.95× range** — not a
+one-off measurement artifact. The equivalence check (`maxDiff = 0` at every
+checkpoint) was re-verified on each of these runs as well.
+
+## Decision
+
+**Branch taken: Ratio < 2× — the claim does not hold on this workload.**
+
+The measured ratio is **1.93×**, consistently reproduced across four
+independent runs. This is meaningfully faster than JavaScript, but it falls
+short of the 2× bar this task set for "the claim holds," and it is far
+short of the kind of multiple (5–10×+) that would make a strong headline
+speed claim. A modern JIT (V8, in this case) on a tight loop over
+`Float32Array`s at this grid size closes most of the gap to ahead-of-time
+compiled WASM.
+
+**Recommendation: do not build a comparison UI (a JS-vs-WASM toggle) for
+this demo.** Shipping a side-by-side comparison advertising "~2× faster"
+would undercut the demo rather than sell it — it invites the reader to focus
+on a modest number instead of the demo itself. The reaction-diffusion demo
+stands on its own as an interactive simulation (the pattern generation,
+presets, and click-to-seed interaction are the actual product); it should
+not be sold on a speed claim at this grid size and substep count.
+
+If a future task increases the grid size substantially, or the workload
+gains more arithmetic intensity per cell, this ratio should be re-measured
+before revisiting the decision — the two implementations may separate more
+at a larger scale where memory-layout and compilation advantages compound,
+but that is a new measurement, not an extrapolation from this one.
+
+## Reasons to trust these numbers
+
+- Equivalence is exact (pixel-identical output across all five checkpoints,
+  and the JS port independently reproduces the Rust unit tests' closed-form
+  values), so this is a comparison between genuinely equivalent
+  implementations, not an accidentally-cheaper JS version.
+- The ratio was stable across four independent full runs (primary run + 3
+  stability checks), all landing in a narrow band, not a single noisy
+  sample.
+- Discard-first-run protocol was followed for both implementations.
+- No production code changed; the JS reference lived only in the session
+  scratchpad and was never imported by any page.
+
+## Reasons for caution
+
+- Headless Chrome, not a windowed browser — CPU scheduling and any
+  compositor/vsync-related overhead differ from a real display, though
+  neither implementation renders during the timed window (rendering is a
+  separate, untimed call), so this shouldn't materially affect the compute
+  comparison.
+- Single machine (Apple M4). Ratios on other CPU microarchitectures
+  (particularly ones with weaker JIT tiers, e.g. lower-end mobile devices)
+  could differ in either direction.
+- `performance.now()` resolution and OS scheduling noise are inherent to
+  any browser-based timing; the four-run stability check was performed
+  specifically to bound this rather than trust a single sample.

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Builds the reaction-diffusion demo to WebAssembly and emits the JS bindings.
+# Run before `cargo run -p site` so the generator can copy the artifacts.
+set -euo pipefail
+
+OUT=static/demos/reaction-diffusion
+
+cargo build -p reaction-diffusion --target wasm32-unknown-unknown --release
+
+mkdir -p "$OUT"
+wasm-bindgen \
+  --target web \
+  --no-typescript \
+  --out-dir "$OUT" \
+  target/wasm32-unknown-unknown/release/reaction_diffusion.wasm
+
+echo "wasm artifacts in $OUT:"
+ls -la "$OUT"

--- a/static/demos/loader.js
+++ b/static/demos/loader.js
@@ -1,0 +1,109 @@
+// Lazy loader for the reaction-diffusion demo. Only this page imports it,
+// so no other page on the site downloads any WebAssembly.
+import init, { Simulation } from "./reaction-diffusion/reaction_diffusion.js";
+
+const PRESETS = {
+  coral:     { feed: 0.0545, kill: 0.0620 },
+  mitosis:   { feed: 0.0367, kill: 0.0649 },
+  solitons:  { feed: 0.0300, kill: 0.0620 },
+  worms:     { feed: 0.0780, kill: 0.0610 },
+};
+
+async function main() {
+  const canvas = document.getElementById("rd-canvas");
+  const status = document.getElementById("rd-status");
+  if (!canvas) return;
+
+  const wasm = await init();
+  const sim = new Simulation(220, 140);
+  const w = sim.width(), h = sim.height();
+  canvas.width = w;
+  canvas.height = h;
+
+  const ctx = canvas.getContext("2d");
+  const image = ctx.createImageData(w, h);
+
+  let preset = PRESETS.coral;
+  let running = false;
+  let frames = 0, fpsAt = performance.now();
+
+  const isDark = () => document.documentElement.dataset.theme === "dark";
+
+  function seedCentre() {
+    sim.reset();
+    for (let i = 0; i < 12; i++) {
+      const x = Math.floor(w / 2 + (Math.random() - 0.5) * 40);
+      const y = Math.floor(h / 2 + (Math.random() - 0.5) * 40);
+      sim.seed(x, y, 3);
+    }
+  }
+
+  function draw() {
+    sim.render(isDark());
+    const px = new Uint8ClampedArray(wasm.memory.buffer, sim.pixels_ptr(), sim.pixels_len());
+    image.data.set(px);
+    ctx.putImageData(image, 0, 0);
+  }
+
+  function frame() {
+    if (!running) return;
+    sim.step(preset.feed, preset.kill, 8);
+    draw();
+    frames++;
+    const now = performance.now();
+    if (now - fpsAt >= 1000) {
+      status.textContent = frames + " fps";
+      frames = 0;
+      fpsAt = now;
+    }
+    requestAnimationFrame(frame);
+  }
+
+  function start() {
+    if (running) return;
+    running = true;
+    status.textContent = "running";
+    requestAnimationFrame(frame);
+  }
+
+  function stop() {
+    running = false;
+    status.textContent = "paused";
+  }
+
+  canvas.addEventListener("pointerdown", (e) => {
+    const r = canvas.getBoundingClientRect();
+    const x = Math.floor((e.clientX - r.left) / r.width * w);
+    const y = Math.floor((e.clientY - r.top) / r.height * h);
+    sim.seed(x, y, 4);
+    if (!running) draw();
+  });
+
+  document.getElementById("rd-toggle").addEventListener("click", () => {
+    running ? stop() : start();
+  });
+  document.getElementById("rd-reset").addEventListener("click", () => {
+    seedCentre();
+    draw();
+  });
+  document.querySelectorAll("[data-preset]").forEach((b) => {
+    b.addEventListener("click", () => {
+      preset = PRESETS[b.dataset.preset];
+      seedCentre();
+      if (!running) draw();
+    });
+  });
+
+  seedCentre();
+  draw();
+
+  // Respect a reduced-motion preference: render one frame and wait to be
+  // asked rather than animating unbidden.
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    status.textContent = "paused — reduced motion";
+  } else {
+    start();
+  }
+}
+
+main();

--- a/static/demos/loader.js
+++ b/static/demos/loader.js
@@ -48,6 +48,14 @@ async function main() {
     ctx.putImageData(image, 0, 0);
   }
 
+  // The site's theme toggle mutates data-theme but dispatches no event. A
+  // running sim repaints on its own next frame, but a paused one (by
+  // reduced-motion default or a manual Pause) would otherwise sit rendered
+  // in the wrong palette until the next user interaction.
+  new MutationObserver(() => {
+    if (!running) draw();
+  }).observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+
   function frame(gen) {
     if (!running || gen !== generation) return; // stale chain exits
     sim.step(preset.feed, preset.kill, 8);

--- a/static/demos/loader.js
+++ b/static/demos/loader.js
@@ -12,7 +12,9 @@ const PRESETS = {
 async function main() {
   const canvas = document.getElementById("rd-canvas");
   const status = document.getElementById("rd-status");
-  if (!canvas) return;
+  const toggle = document.getElementById("rd-toggle");
+  const reset = document.getElementById("rd-reset");
+  if (!canvas || !status || !toggle || !reset) return;
 
   const wasm = await init();
   const sim = new Simulation(220, 140);
@@ -25,6 +27,7 @@ async function main() {
 
   let preset = PRESETS.coral;
   let running = false;
+  let generation = 0;
   let frames = 0, fpsAt = performance.now();
 
   const isDark = () => document.documentElement.dataset.theme === "dark";
@@ -45,8 +48,8 @@ async function main() {
     ctx.putImageData(image, 0, 0);
   }
 
-  function frame() {
-    if (!running) return;
+  function frame(gen) {
+    if (!running || gen !== generation) return; // stale chain exits
     sim.step(preset.feed, preset.kill, 8);
     draw();
     frames++;
@@ -56,19 +59,24 @@ async function main() {
       frames = 0;
       fpsAt = now;
     }
-    requestAnimationFrame(frame);
+    requestAnimationFrame(() => frame(gen));
   }
 
   function start() {
     if (running) return;
     running = true;
+    generation++;
+    const gen = generation;
     status.textContent = "running";
-    requestAnimationFrame(frame);
+    toggle.textContent = "Pause";
+    requestAnimationFrame(() => frame(gen));
   }
 
   function stop() {
     running = false;
+    generation++; // orphans any pending frame from the current chain
     status.textContent = "paused";
+    toggle.textContent = "Resume";
   }
 
   canvas.addEventListener("pointerdown", (e) => {
@@ -79,10 +87,10 @@ async function main() {
     if (!running) draw();
   });
 
-  document.getElementById("rd-toggle").addEventListener("click", () => {
+  toggle.addEventListener("click", () => {
     running ? stop() : start();
   });
-  document.getElementById("rd-reset").addEventListener("click", () => {
+  reset.addEventListener("click", () => {
     seedCentre();
     draw();
   });
@@ -101,9 +109,14 @@ async function main() {
   // asked rather than animating unbidden.
   if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
     status.textContent = "paused — reduced motion";
+    toggle.textContent = "Resume";
   } else {
     start();
   }
 }
 
-main();
+main().catch((err) => {
+  const status = document.getElementById("rd-status");
+  if (status) status.textContent = "failed to load";
+  console.error("reaction-diffusion demo failed to load:", err);
+});


### PR DESCRIPTION
The first WebAssembly on the site: an interactive Gray-Scott reaction-diffusion simulation.

## What this adds

- **`crates/demos/reaction-diffusion`** — the simulation as a plain Rust crate with no `wasm-bindgen` in the physics module, so it is unit-tested natively rather than through a headless browser. A thin `#[wasm_bindgen]` wrapper shares pixels through linear memory: one bulk copy into `ImageData` per frame, no per-value marshalling.
- **A `Demos` route** and a demo page at `/demos/reaction-diffusion/` with four presets, click-to-seed, pause and reset. Colours come from the site's design tokens, so it belongs to the page in both themes.
- **A lazy ES-module loader** imported by exactly one page — no bundler, no npm. Every other page downloads zero WebAssembly.
- **CI builds the wasm** and fails the build if the artifacts are missing. They are gitignored, so nothing in the committed tree produces them and no test would otherwise catch their absence.

## Size

27,640 bytes of wasm; **12,350 gzipped** — about 1/28th of the Inter font already on the site.

## On performance

The demo is deliberately **not** sold on speed. A benchmark against a genuinely equivalent JavaScript implementation — verified pixel-identical before timing — measured **1.93×**, below the 2× threshold the plan set for making that claim. No comparison UI was built. See `docs/superpowers/wasm-benchmark.md`.

## Accessibility and degradation

`prefers-reduced-motion` gets a still first frame rather than an unbidden animation, and the canvas repaints on a theme change even while paused. With JavaScript disabled the page explains itself; the rest of the site is unaffected.

70 tests, clippy clean at `-D warnings`, zero lint suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)