### PR TITLE
Embed the resume as inline vector pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
         test -f dist/resume/page-01.svg
         test -f dist/assets/paul_maxwell_resume.pdf
+        grep -q 'class="resume-page" src="/resume/page-01.svg"' dist/resume/index.html
         ls -la dist/resume/
 
     - name: Setup Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,12 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.RESUME_GITHUB_TOKEN }}
       run: ./scripts/fetch-resume.sh
 
+    - name: Install poppler
+      run: sudo apt-get update && sudo apt-get install -y poppler-utils
+
+    - name: Render resume
+      run: ./scripts/render-resume.sh
+
     - name: Install wasm-bindgen-cli
       run: cargo install wasm-bindgen-cli --version 0.2.127 --locked
 
@@ -49,6 +55,12 @@ jobs:
         test -f dist/demos/reaction-diffusion/reaction_diffusion_bg.wasm
         test -f dist/demos/reaction-diffusion/reaction_diffusion.js
         ls -la dist/demos/reaction-diffusion/
+
+    - name: Verify resume shipped
+      run: |
+        test -f dist/resume/page-01.svg
+        test -f dist/assets/paul_maxwell_resume.pdf
+        ls -la dist/resume/
 
     - name: Setup Pages
       uses: actions/configure-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ set_env.sh
 /assets/paul_maxwell_resume.pdf
 .superpowers/
 /static/demos/reaction-diffusion/
+/static/resume/

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -87,6 +87,24 @@ fn sitemap_xml(site: &Site, extra: &[&str]) -> String {
     )
 }
 
+/// Finds the rendered resume pages and extracted text, if they exist.
+/// Returns rooted URLs in page order.
+fn resume_artifacts(root: &Path) -> Result<(Vec<String>, String)> {
+    let dir = root.join("static/resume");
+    if !dir.exists() {
+        return Ok((Vec::new(), String::new()));
+    }
+    let mut pages: Vec<String> = std::fs::read_dir(&dir)?
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.starts_with("page-") && n.ends_with(".svg"))
+        .map(|n| format!("/resume/{n}"))
+        .collect();
+    pages.sort();
+    let text = std::fs::read_to_string(dir.join("resume.txt")).unwrap_or_default();
+    Ok((pages, text))
+}
+
 /// Renders the whole site into `out`. With `strict`, a missing resume PDF is a
 /// hard error; without it, a warning — so local builds work without the token
 /// that CI uses to fetch the private release.
@@ -94,12 +112,21 @@ pub fn build(root: &Path, out: &Path, strict: bool) -> Result<Vec<PathBuf>> {
     let site = Site::load(&root.join(CONTENT))?;
     let mut written = Vec::new();
 
+    let (resume_pages, resume_text) = resume_artifacts(root)?;
+    if resume_pages.is_empty() {
+        let msg = "resume pages not rendered — run scripts/render-resume.sh";
+        if strict {
+            anyhow::bail!("{msg}");
+        }
+        eprintln!("warning: {msg} (non-strict build, continuing)");
+    }
+
     for route in Route::ALL {
         let markup = match route {
             Route::Index => pages::index::render(&site),
             Route::About => pages::about::render(&site),
             Route::Projects => pages::projects::render(&site),
-            Route::Resume => pages::resume::render(&site),
+            Route::Resume => pages::resume::render(&site, &resume_pages, &resume_text),
             Route::Demos => pages::demos::render(&site),
         };
         write(&out.join(route.output_path()), &markup.into_string(), &mut written)?;
@@ -371,6 +398,25 @@ mod tests {
             "demo page must load the wasm demo: {demo_html}"
         );
 
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn build_embeds_the_rendered_resume_pages() {
+        let tmp = std::env::temp_dir().join("site-resume-test");
+        let _ = std::fs::remove_dir_all(&tmp);
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+
+        let html = std::fs::read_to_string(tmp.join("resume/index.html")).unwrap();
+        let (pages, _) = resume_artifacts(Path::new("../..")).unwrap();
+        for page in &pages {
+            assert!(html.contains(page.as_str()), "resume page {page} not referenced");
+        }
+        assert!(
+            html.contains("/assets/paul_maxwell_resume.pdf"),
+            "download link missing from the built page"
+        );
+        assert!(!html.contains("<object"), "the old PDF object embed should be gone");
         std::fs::remove_dir_all(&tmp).ok();
     }
 

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -1,6 +1,7 @@
 use crate::checks;
 use crate::content::Site;
-use crate::{pages, route::Route, theme};
+use crate::pages::resume::ResumePage;
+use crate::{pages, route::Route, text, theme};
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
@@ -87,24 +88,74 @@ fn sitemap_xml(site: &Site, extra: &[&str]) -> String {
     )
 }
 
+/// Parses the leading numeric value out of an SVG length attribute value
+/// such as `612pt` or `792` — the unit is ignored, since only the ratio
+/// between width and height matters here (the CSS governs actual display
+/// size).
+fn parse_svg_length(value: &str) -> Option<u32> {
+    let numeric: String = value.chars().take_while(|c| c.is_ascii_digit() || *c == '.').collect();
+    if numeric.is_empty() {
+        return None;
+    }
+    numeric.parse::<f64>().ok().map(|n| n.round() as u32)
+}
+
+/// Extracts `attr="value"` from an SVG's opening `<svg ...>` tag and parses
+/// its leading numeric length.
+fn svg_attr_length(open_tag: &str, attr: &str) -> Option<u32> {
+    let marker = format!("{attr}=\"");
+    let start = open_tag.find(&marker)? + marker.len();
+    let value = &open_tag[start..];
+    let end = value.find('"')?;
+    parse_svg_length(&value[..end])
+}
+
+/// Reads the `width`/`height` declared on an SVG's root element. These
+/// files are produced by our own `pdftocairo` render step, so if they
+/// aren't there, something about the render is genuinely broken — fail
+/// loudly rather than silently shipping an image with no reserved space.
+fn svg_dimensions(svg: &str) -> Result<(u32, u32)> {
+    // Locate the `<svg` tag rather than assuming it opens the file: an XML
+    // declaration (`<?xml version="1.0"?>`) usually precedes it, and that
+    // itself contains a `>` — the first in the document — so scanning for
+    // the plain first `>` would truncate the tag before it even starts.
+    let tag_start = svg.find("<svg").context("no <svg> root element found")?;
+    let tag_end = svg[tag_start..].find('>').map(|i| tag_start + i + 1).unwrap_or(svg.len());
+    let open_tag = &svg[tag_start..tag_end];
+    let width = svg_attr_length(open_tag, "width").context("no parsable width on <svg> root")?;
+    let height = svg_attr_length(open_tag, "height").context("no parsable height on <svg> root")?;
+    Ok((width, height))
+}
+
 /// Finds the rendered resume pages and extracted text, if they exist.
-/// Returns rooted URLs in page order.
-fn resume_artifacts(root: &Path) -> Result<(Vec<String>, String)> {
+/// Pages come back in page order; text is normalised (ligatures expanded,
+/// split small-caps headings joined, trailing form feed stripped).
+fn resume_artifacts(root: &Path) -> Result<(Vec<ResumePage>, String)> {
     let dir = root.join("static/resume");
     if !dir.exists() {
         return Ok((Vec::new(), String::new()));
     }
-    let mut pages: Vec<String> = std::fs::read_dir(&dir)?
+    let mut names: Vec<String> = std::fs::read_dir(&dir)?
         .filter_map(|e| e.ok())
         .filter_map(|e| e.file_name().into_string().ok())
         .filter(|n| n.starts_with("page-") && n.ends_with(".svg"))
-        .map(|n| format!("/resume/{n}"))
         .collect();
-    pages.sort();
+    names.sort();
+
+    let mut pages = Vec::with_capacity(names.len());
+    for name in names {
+        let path = dir.join(&name);
+        let svg = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        let (width, height) = svg_dimensions(&svg)
+            .with_context(|| format!("{} has no parsable svg dimensions", path.display()))?;
+        pages.push(ResumePage { url: format!("/resume/{name}"), width, height });
+    }
+
     // Dotfile so `copy_tree`'s existing dotfile exclusion keeps it out of the
     // published output for free — no new exclusion rule needed.
-    let text = std::fs::read_to_string(dir.join(".resume.txt")).unwrap_or_default();
-    Ok((pages, text))
+    let raw_text = std::fs::read_to_string(dir.join(".resume.txt")).unwrap_or_default();
+    Ok((pages, text::normalize(&raw_text)))
 }
 
 /// Renders the whole site into `out`. With `strict`, a missing resume PDF is a
@@ -412,19 +463,32 @@ mod tests {
         let html = std::fs::read_to_string(tmp.join("resume/index.html")).unwrap();
         let (pages, _) = resume_artifacts(Path::new("../..")).unwrap();
         for page in &pages {
-            assert!(html.contains(page.as_str()), "resume page {page} not referenced");
+            assert!(html.contains(page.url.as_str()), "resume page {} not referenced", page.url);
         }
-        assert_eq!(
-            html.matches("resume-page").count(),
-            pages.len(),
-            "rendered image count must match discovered pages"
-        );
+        // No count assertion here: `cargo test` runs before the artifacts
+        // exist in CI (see .github/workflows/deploy.yml), so both sides of
+        // any such count would read zero and the assertion would be inert.
+        // The equivalent check that actually runs against real artifacts
+        // lives in the "Verify resume shipped" CI step.
         assert!(
             html.contains("/assets/paul_maxwell_resume.pdf"),
             "download link missing from the built page"
         );
         assert!(!html.contains("<object"), "the old PDF object embed should be gone");
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    fn write_svg(path: &Path, width: &str, height: &str) {
+        std::fs::write(
+            path,
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 612 792">
+<rect width="10" height="10"/>
+</svg>"#
+            ),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -434,18 +498,15 @@ mod tests {
         std::fs::create_dir_all(dir.join("static/resume")).unwrap();
         // Created deliberately out of order — read_dir order is not guaranteed.
         for n in ["page-03.svg", "page-01.svg", "page-02.svg"] {
-            std::fs::write(dir.join("static/resume").join(n), "<svg/>").unwrap();
+            write_svg(&dir.join("static/resume").join(n), "612pt", "792pt");
         }
         std::fs::write(dir.join("static/resume/.resume.txt"), "Aho-Corasick").unwrap();
 
         let (pages, text) = resume_artifacts(&dir).unwrap();
+        let urls: Vec<&str> = pages.iter().map(|p| p.url.as_str()).collect();
         assert_eq!(
-            pages,
-            vec![
-                "/resume/page-01.svg".to_string(),
-                "/resume/page-02.svg".to_string(),
-                "/resume/page-03.svg".to_string(),
-            ],
+            urls,
+            vec!["/resume/page-01.svg", "/resume/page-02.svg", "/resume/page-03.svg"],
             "pages must come back sorted by page number"
         );
         assert_eq!(text, "Aho-Corasick");
@@ -460,6 +521,39 @@ mod tests {
         let (pages, text) = resume_artifacts(&dir).unwrap();
         assert!(pages.is_empty());
         assert!(text.is_empty());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resume_artifacts_parses_each_pages_intrinsic_dimensions() {
+        let dir = std::env::temp_dir().join("resume-artifacts-dimensions-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("static/resume")).unwrap();
+        write_svg(&dir.join("static/resume/page-01.svg"), "612pt", "792pt");
+
+        let (pages, _) = resume_artifacts(&dir).unwrap();
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].width, 612, "width must be parsed from the svg root, ignoring the unit");
+        assert_eq!(pages[0].height, 792, "height must be parsed from the svg root, ignoring the unit");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resume_artifacts_fails_loudly_on_a_page_with_no_parsable_dimensions() {
+        let dir = std::env::temp_dir().join("resume-artifacts-malformed-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("static/resume")).unwrap();
+        std::fs::write(
+            dir.join("static/resume/page-01.svg"),
+            r#"<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>"#,
+        )
+        .unwrap();
+
+        let err = resume_artifacts(&dir).expect_err("missing svg dimensions must error, not skip");
+        assert!(
+            err.to_string().contains("page-01.svg"),
+            "error should name the offending file: {err}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -101,7 +101,9 @@ fn resume_artifacts(root: &Path) -> Result<(Vec<String>, String)> {
         .map(|n| format!("/resume/{n}"))
         .collect();
     pages.sort();
-    let text = std::fs::read_to_string(dir.join("resume.txt")).unwrap_or_default();
+    // Dotfile so `copy_tree`'s existing dotfile exclusion keeps it out of the
+    // published output for free — no new exclusion rule needed.
+    let text = std::fs::read_to_string(dir.join(".resume.txt")).unwrap_or_default();
     Ok((pages, text))
 }
 
@@ -412,12 +414,53 @@ mod tests {
         for page in &pages {
             assert!(html.contains(page.as_str()), "resume page {page} not referenced");
         }
+        assert_eq!(
+            html.matches("resume-page").count(),
+            pages.len(),
+            "rendered image count must match discovered pages"
+        );
         assert!(
             html.contains("/assets/paul_maxwell_resume.pdf"),
             "download link missing from the built page"
         );
         assert!(!html.contains("<object"), "the old PDF object embed should be gone");
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn resume_artifacts_returns_pages_in_order_regardless_of_directory_order() {
+        let dir = std::env::temp_dir().join("resume-artifacts-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("static/resume")).unwrap();
+        // Created deliberately out of order — read_dir order is not guaranteed.
+        for n in ["page-03.svg", "page-01.svg", "page-02.svg"] {
+            std::fs::write(dir.join("static/resume").join(n), "<svg/>").unwrap();
+        }
+        std::fs::write(dir.join("static/resume/.resume.txt"), "Aho-Corasick").unwrap();
+
+        let (pages, text) = resume_artifacts(&dir).unwrap();
+        assert_eq!(
+            pages,
+            vec![
+                "/resume/page-01.svg".to_string(),
+                "/resume/page-02.svg".to_string(),
+                "/resume/page-03.svg".to_string(),
+            ],
+            "pages must come back sorted by page number"
+        );
+        assert_eq!(text, "Aho-Corasick");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resume_artifacts_is_empty_when_nothing_has_been_rendered() {
+        let dir = std::env::temp_dir().join("resume-artifacts-empty-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (pages, text) = resume_artifacts(&dir).unwrap();
+        assert!(pages.is_empty());
+        assert!(text.is_empty());
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/crates/site/src/main.rs
+++ b/crates/site/src/main.rs
@@ -4,6 +4,7 @@ mod components;
 mod content;
 mod pages;
 mod route;
+mod text;
 mod theme;
 
 use anyhow::Result;

--- a/crates/site/src/pages/resume.rs
+++ b/crates/site/src/pages/resume.rs
@@ -6,18 +6,24 @@ use maud::{html, Markup};
 /// Published location of the PDF fetched from the private release.
 pub const RESUME_PDF: &str = "/assets/paul_maxwell_resume.pdf";
 
-pub fn render(site: &Site) -> Markup {
+/// Renders the resume as inline vector pages with a hidden text layer.
+///
+/// `pages` holds rooted URLs in page order; `text` is the plain-text
+/// extraction. With no pages — a local build that has not run
+/// `scripts/render-resume.sh` — the page degrades to the download link.
+pub fn render(site: &Site, pages: &[String], text: &str) -> Markup {
     let main = html! {
         h1 { "Resume" }
         p .prose {
             a href=(RESUME_PDF) download { "Download PDF" }
         }
-        object data=(RESUME_PDF) type="application/pdf" aria-label="Resume PDF"
-            style="width:100%;height:80vh;border:1px solid var(--rule);margin-top:1.5rem" {
-            p .prose {
-                "Your browser cannot display the embedded PDF. "
-                a href=(RESUME_PDF) download { "Download it instead." }
-            }
+
+        @for (i, page) in pages.iter().enumerate() {
+            img .resume-page src=(page) alt=(format!("Resume page {} of {}", i + 1, pages.len()));
+        }
+
+        @if !text.is_empty() {
+            div .visually-hidden { (text) }
         }
     };
     shell::layout(site, Route::Resume, "Resume", main)
@@ -26,14 +32,45 @@ pub fn render(site: &Site) -> Markup {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+
+    fn pages() -> Vec<String> {
+        vec!["/resume/page-01.svg".to_string(), "/resume/page-02.svg".to_string()]
+    }
 
     #[test]
-    fn resume_offers_a_download_and_embeds_the_pdf() {
-        let site = Site::load(Path::new("../../content/site.toml")).unwrap();
-        let out = render(&site).into_string();
+    fn resume_shows_one_image_per_page_in_order() {
+        let out = render(&crate::content::fixture_site(), &pages(), "Paul Maxwell").into_string();
+        let first = out.find("/resume/page-01.svg").expect("page 1 missing");
+        let second = out.find("/resume/page-02.svg").expect("page 2 missing");
+        assert!(first < second, "pages rendered out of order");
+        assert_eq!(out.matches("<img").count(), 2, "expected exactly one img per page");
+    }
+
+    #[test]
+    fn resume_keeps_the_pdf_download() {
+        let out = render(&crate::content::fixture_site(), &pages(), "text").into_string();
         assert!(out.contains(&format!(r#"href="{RESUME_PDF}""#)), "download link missing");
         assert!(out.contains("download"), "download attribute missing");
-        assert!(out.contains(RESUME_PDF), "embed source missing");
+    }
+
+    #[test]
+    fn resume_embeds_the_extracted_text_for_screen_readers() {
+        let out = render(&crate::content::fixture_site(), &pages(), "Aho-Corasick").into_string();
+        assert!(out.contains("visually-hidden"), "hidden text container missing");
+        assert!(out.contains("Aho-Corasick"), "extracted text not embedded");
+    }
+
+    #[test]
+    fn resume_without_rendered_pages_still_offers_the_download() {
+        let out = render(&crate::content::fixture_site(), &[], "").into_string();
+        assert!(out.contains(&format!(r#"href="{RESUME_PDF}""#)), "download link missing");
+        assert_eq!(out.matches("<img").count(), 0, "no pages should render no images");
+    }
+
+    #[test]
+    fn extracted_text_is_escaped_not_injected() {
+        let out = render(&crate::content::fixture_site(), &pages(), "a <script>x</script> b").into_string();
+        assert!(!out.contains("<script>x</script>"), "raw markup leaked from the PDF text");
+        assert!(out.contains("&lt;script&gt;"), "text should be HTML-escaped");
     }
 }

--- a/crates/site/src/pages/resume.rs
+++ b/crates/site/src/pages/resume.rs
@@ -6,12 +6,31 @@ use maud::{html, Markup};
 /// Published location of the PDF fetched from the private release.
 pub const RESUME_PDF: &str = "/assets/paul_maxwell_resume.pdf";
 
+/// One rendered resume page: its rooted URL plus the intrinsic dimensions
+/// declared on the source SVG's root element, so the `<img>` can reserve
+/// the correct box before the file loads.
+#[derive(Debug)]
+pub struct ResumePage {
+    pub url: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Splits normalised extracted text on blank lines into paragraph blocks.
+/// `.visually-hidden` sets `white-space: nowrap`, which collapses newlines
+/// in a single text node — splitting into `<p>` elements is what gives the
+/// accessibility tree headings and boundaries to skim by.
+fn paragraphs(text: &str) -> Vec<&str> {
+    text.split("\n\n").map(str::trim).filter(|p| !p.is_empty()).collect()
+}
+
 /// Renders the resume as inline vector pages with a hidden text layer.
 ///
-/// `pages` holds rooted URLs in page order; `text` is the plain-text
-/// extraction. With no pages — a local build that has not run
-/// `scripts/render-resume.sh` — the page degrades to the download link.
-pub fn render(site: &Site, pages: &[String], text: &str) -> Markup {
+/// `pages` holds each page in order with its intrinsic size; `text` is the
+/// normalised plain-text extraction. With no pages — a local build that has
+/// not run `scripts/render-resume.sh` — the page degrades to the download
+/// link.
+pub fn render(site: &Site, pages: &[ResumePage], text: &str) -> Markup {
     let main = html! {
         h1 { "Resume" }
         p .prose {
@@ -20,12 +39,21 @@ pub fn render(site: &Site, pages: &[String], text: &str) -> Markup {
 
         // alt="" is deliberate: the images are decorative once the hidden
         // text layer below carries the actual content for assistive tech.
+        // width/height are the SVG's own declared dimensions — the browser
+        // derives the intrinsic aspect ratio from them and reserves the
+        // correct box before the file loads, instead of collapsing to zero
+        // height and jumping the page.
         @for page in pages {
-            img .resume-page src=(page) alt="";
+            img .resume-page src=(page.url) width=(page.width) height=(page.height) alt="";
         }
 
         @if !text.is_empty() {
-            div .visually-hidden { (text) }
+            div .visually-hidden {
+                h2 { "Resume, text version" }
+                @for paragraph in paragraphs(text) {
+                    p { (paragraph) }
+                }
+            }
         }
     };
     shell::layout(site, Route::Resume, "Resume", main)
@@ -35,8 +63,11 @@ pub fn render(site: &Site, pages: &[String], text: &str) -> Markup {
 mod tests {
     use super::*;
 
-    fn pages() -> Vec<String> {
-        vec!["/resume/page-01.svg".to_string(), "/resume/page-02.svg".to_string()]
+    fn pages() -> Vec<ResumePage> {
+        vec![
+            ResumePage { url: "/resume/page-01.svg".to_string(), width: 612, height: 792 },
+            ResumePage { url: "/resume/page-02.svg".to_string(), width: 612, height: 792 },
+        ]
     }
 
     #[test]
@@ -46,6 +77,18 @@ mod tests {
         let second = out.find("/resume/page-02.svg").expect("page 2 missing");
         assert!(first < second, "pages rendered out of order");
         assert_eq!(out.matches("<img").count(), 2, "expected exactly one img per page");
+    }
+
+    #[test]
+    fn resume_image_carries_its_parsed_intrinsic_dimensions() {
+        let mut pages = pages();
+        pages[0].width = 612;
+        pages[0].height = 792;
+        let out = render(&crate::content::fixture_site(), &pages, "text").into_string();
+        assert!(
+            out.contains(r#"src="/resume/page-01.svg" width="612" height="792""#),
+            "img missing its parsed width/height attributes: {out}"
+        );
     }
 
     #[test]
@@ -60,6 +103,21 @@ mod tests {
         let out = render(&crate::content::fixture_site(), &pages(), "Aho-Corasick").into_string();
         assert!(out.contains("visually-hidden"), "hidden text container missing");
         assert!(out.contains("Aho-Corasick"), "extracted text not embedded");
+    }
+
+    #[test]
+    fn resume_hidden_text_is_split_into_paragraphs_behind_a_heading() {
+        let text = "Paul Maxwell\nWashington, DC\n\nEXPERIENCE\nP-1 AI, Remote\n\nEDUCATION\nGeorgia Tech";
+        let out = render(&crate::content::fixture_site(), &pages(), text).into_string();
+        assert!(
+            out.contains("<h2>Resume, text version</h2>"),
+            "missing the navigable heading: {out}"
+        );
+        assert_eq!(
+            out.matches("<p>").count(),
+            3,
+            "expected one <p> per blank-line-separated block: {out}"
+        );
     }
 
     #[test]

--- a/crates/site/src/pages/resume.rs
+++ b/crates/site/src/pages/resume.rs
@@ -18,8 +18,10 @@ pub fn render(site: &Site, pages: &[String], text: &str) -> Markup {
             a href=(RESUME_PDF) download { "Download PDF" }
         }
 
-        @for (i, page) in pages.iter().enumerate() {
-            img .resume-page src=(page) alt=(format!("Resume page {} of {}", i + 1, pages.len()));
+        // alt="" is deliberate: the images are decorative once the hidden
+        // text layer below carries the actual content for assistive tech.
+        @for page in pages {
+            img .resume-page src=(page) alt="";
         }
 
         @if !text.is_empty() {

--- a/crates/site/src/text.rs
+++ b/crates/site/src/text.rs
@@ -1,0 +1,129 @@
+//! Normalises text extracted from the resume PDF by `pdftotext`.
+//!
+//! Kept in Rust rather than the shell script that produces the raw
+//! extraction: `pdftotext`'s output has PDF-rendering artefacts (ligatures,
+//! split small-caps headings) that need fixing identically on every
+//! platform this build runs on, and BSD `sed` (macOS) and GNU `sed` (CI)
+//! disagree on `\b`-style word-boundary regexes.
+
+/// Ligatures `pdftotext` emits verbatim, expanded to their ASCII letter
+/// sequences so full-text search and screen readers see ordinary words
+/// instead of a single unfamiliar glyph.
+const LIGATURES: [(char, &str); 5] = [
+    ('\u{FB01}', "fi"),
+    ('\u{FB02}', "fl"),
+    ('\u{FB00}', "ff"),
+    ('\u{FB03}', "ffi"),
+    ('\u{FB04}', "ffl"),
+];
+
+fn expand_ligatures(text: &str) -> String {
+    let mut out = text.to_string();
+    for (ligature, expansion) in LIGATURES {
+        out = out.replace(ligature, expansion);
+    }
+    out
+}
+
+/// The LaTeX resume template renders section headings in small caps: a
+/// full-size initial letter followed by a smaller run of capitals.
+/// `pdftotext` extracts that as two separate tokens — `E XPERIENCE` — which
+/// a screen reader reads as "E, Xperience" and a crawler indexes as
+/// "XPERIENCE". This joins a lone uppercase ASCII letter back onto an
+/// immediately following uppercase run.
+///
+/// Deliberately narrow so real text survives untouched: the first token
+/// must be *exactly* one uppercase letter (so `P-1` in "P-1 AI" doesn't
+/// qualify), and the second must be two or more uppercase letters with
+/// nothing else (so a lone `I` used as a job-level suffix, e.g. "Engineer I
+/// (Jan", never merges — "(Jan" isn't all-uppercase).
+fn join_split_small_caps(line: &str) -> String {
+    let is_lone_capital =
+        |word: &str| word.len() == 1 && word.chars().next().is_some_and(|c| c.is_ascii_uppercase());
+    let is_upper_run =
+        |word: &str| word.len() >= 2 && word.chars().all(|c| c.is_ascii_uppercase());
+
+    let tokens: Vec<&str> = line.split(' ').collect();
+    let mut out: Vec<String> = Vec::with_capacity(tokens.len());
+    let mut i = 0;
+    while i < tokens.len() {
+        match tokens.get(i + 1) {
+            Some(next) if is_lone_capital(tokens[i]) && is_upper_run(next) => {
+                out.push(format!("{}{}", tokens[i], next));
+                i += 2;
+            }
+            _ => {
+                out.push(tokens[i].to_string());
+                i += 1;
+            }
+        }
+    }
+    out.join(" ")
+}
+
+/// Normalises text extracted from the resume PDF: expands ligatures, joins
+/// split small-caps headings, and strips the trailing form-feed page marker
+/// `pdftotext` appends after the last page.
+pub fn normalize(text: &str) -> String {
+    let text = expand_ligatures(text);
+    let text = text.replace('\u{c}', "");
+    text.lines().map(join_split_small_caps).collect::<Vec<_>>().join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn joins_a_split_small_caps_heading() {
+        assert_eq!(join_split_small_caps("E XPERIENCE"), "EXPERIENCE");
+        assert_eq!(join_split_small_caps("E DUCATION"), "EDUCATION");
+    }
+
+    #[test]
+    fn joins_multiple_split_headings_on_one_line() {
+        assert_eq!(join_split_small_caps("P ROGRAMMING S KILLS"), "PROGRAMMING SKILLS");
+        assert_eq!(
+            join_split_small_caps("A DDITIONAL C REDENTIALS AND ACCOMPLISHMENTS"),
+            "ADDITIONAL CREDENTIALS AND ACCOMPLISHMENTS"
+        );
+    }
+
+    #[test]
+    fn leaves_a_hyphenated_initialism_untouched() {
+        assert_eq!(join_split_small_caps("P-1 AI, Remote"), "P-1 AI, Remote");
+    }
+
+    #[test]
+    fn leaves_a_bare_initialism_untouched() {
+        assert_eq!(join_split_small_caps("Computer Science; GPA: 4.0"), "Computer Science; GPA: 4.0");
+    }
+
+    #[test]
+    fn leaves_a_job_level_suffix_untouched() {
+        assert_eq!(
+            join_split_small_caps("Senior Software Engineer I (Jan 2023 – Dec 2023)"),
+            "Senior Software Engineer I (Jan 2023 – Dec 2023)"
+        );
+    }
+
+    #[test]
+    fn expands_every_ligature_to_its_ascii_letters() {
+        assert_eq!(expand_ligatures("One of 24 \u{FB01}nishers"), "One of 24 finishers");
+        assert_eq!(expand_ligatures("workflow: \u{FB02}"), "workflow: fl");
+        assert_eq!(expand_ligatures("sti\u{FB00}ness"), "stiffness");
+        assert_eq!(expand_ligatures("o\u{FB03}ce"), "office");
+        assert_eq!(expand_ligatures("wa\u{FB04}e"), "waffle");
+    }
+
+    #[test]
+    fn normalize_strips_the_trailing_form_feed_page_marker() {
+        assert_eq!(normalize("last line\n\u{c}"), "last line");
+    }
+
+    #[test]
+    fn normalize_fixes_a_realistic_extraction_end_to_end() {
+        let raw = "E XPERIENCE\nP-1 AI, Remote\n\u{FB01}nishers and workflow\u{FB02}\n\u{c}";
+        assert_eq!(normalize(raw), "EXPERIENCE\nP-1 AI, Remote\nfinishers and workflowfl");
+    }
+}

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -178,6 +178,27 @@ h2 {{ font-size: 24px; letter-spacing: -0.02em; font-weight: 600; }}
 .item .year {{ text-align: right; }}
 .org {{ color: var(--accent); }}
 
+.resume-page {{
+  display: block;
+  width: 100%;
+  max-width: 780px;
+  height: auto;
+  margin: calc(var(--space) * 3) 0;
+  border: 1px solid var(--rule);
+  background: #FFFFFF;
+}}
+.visually-hidden {{
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}}
+
 /* The rail becomes a top bar before the grid gets cramped. */
 @media (max-width: 640px) {{
   .layout {{ grid-template-columns: 1fr; }}

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -273,6 +273,17 @@ mod tests {
     }
 
     #[test]
+    fn resume_page_classes_used_in_markup_are_defined_here() {
+        // pages/resume.rs writes `.resume-page` and `.visually-hidden` with
+        // nothing tying them to this stylesheet. If `.visually-hidden` were
+        // ever dropped here, the failure would be loud and public — five
+        // kilobytes of resume text rendered as visible body copy.
+        let css = stylesheet();
+        assert!(css.contains(".resume-page {"), "stylesheet missing .resume-page: {css}");
+        assert!(css.contains(".visually-hidden {"), "stylesheet missing .visually-hidden: {css}");
+    }
+
+    #[test]
     fn theme_toggle_uses_the_surface_token_as_its_background() {
         let css = stylesheet();
         assert!(

--- a/docs/superpowers/plans/2026-08-13-seamless-resume-embed.md
+++ b/docs/superpowers/plans/2026-08-13-seamless-resume-embed.md
@@ -1,0 +1,411 @@
+# Seamless Resume Embed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the browser's PDF viewer on `/resume/` with the resume rendered inline as vector SVG, plus a hidden text layer, so it looks like part of the page on every device and is readable by screen readers and crawlers.
+
+**Architecture:** A build-time script converts the release PDF to one SVG per page and extracts its text with poppler. The generator discovers those artifacts and renders them as images with a visually-hidden text block. The PDF download link stays. No change to the upstream LaTeX repository.
+
+**Tech Stack:** poppler (`pdftocairo`, `pdftotext`, `pdfinfo`), Rust 1.92, `maud` 0.27.
+
+## Why vector rather than raster
+
+Measured on the real resume (1 page, US Letter):
+
+| Output | Size | Verdict |
+|---|---|---|
+| PNG 110 dpi | 329 KB | soft on retina displays |
+| PNG grayscale 150 dpi | 199 KB | best raster, still degrades when zoomed |
+| JPEG q88 150 dpi | 398 KB | larger *and* ringing artifacts on text |
+| **SVG (vector)** | **592 KB raw, 69 KB gzipped** | crisp at any zoom |
+
+GitHub Pages serves SVG with `content-encoding: gzip` (verified against the live `favicon.svg`), so 69 KB is what a visitor downloads. `pdftocairo -svg` outlines glyphs as paths, so the SVG carries no selectable text — which is exactly what the hidden text layer is for.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **Zero `#[allow(dead_code)]` anywhere in the tree.** There are none today.
+- CI gates deploy on `cargo clippy --all-targets -- -D warnings` and `cargo test --all`. A red build must never publish.
+- No new Rust dependencies, no npm, no bundler.
+- **No external hosts.** Everything self-hosted.
+- The generated SVG and text are **build artifacts, not source** — git-ignored, never committed, exactly like the wasm.
+- **The PDF download link must remain**, and must keep pointing at `/assets/paul_maxwell_resume.pdf`. It is what recruiters actually want.
+- The resume page must remain legible in both themes; light is the site default.
+- `content/site.toml` prose is approved and fixed — do not reword existing copy.
+- The inline theme scripts in `shell.rs`/`rail.rs` use double-quoted JS deliberately, so their un-escaped tests are falsifying. Do not touch them.
+- Existing behaviour that must not regress: `checks::verify` fails the build on any dead internal link or missing asset; the demo page keeps its own canonical; wasm loads only on the demo page.
+
+**A note on tests, carried from earlier buckets:** this project has produced five tests that could not fail, every one because the input made the assertion trivially true. **If a closed-form expected value exists, assert it.** Prefer equality over `assert_ne!` and over threshold comparisons.
+
+---
+
+### Task 1: Render the PDF to SVG and text
+
+**Files:**
+- Create: `scripts/render-resume.sh`
+- Modify: `.gitignore`
+
+**Interfaces:**
+- Consumes: `assets/paul_maxwell_resume.pdf` (fetched from the private release by `scripts/fetch-resume.sh`).
+- Produces: `static/resume/page-N.svg` for each page, one-indexed and zero-padded to two digits (`page-01.svg`), plus `static/resume/resume.txt`. Task 2 discovers these; Task 3 builds them in CI.
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/render-resume.sh` and `chmod +x` it:
+
+```bash
+#!/bin/bash
+# Renders the resume PDF to one SVG per page plus a plain-text extraction,
+# for inline display on /resume/. Run after scripts/fetch-resume.sh and
+# before `cargo run -p site`.
+#
+# Vector rather than raster: the SVG is ~69 KB gzipped and stays crisp at
+# any zoom, where a 150 dpi PNG is ~199 KB and goes soft.
+set -euo pipefail
+
+PDF=assets/paul_maxwell_resume.pdf
+OUT=static/resume
+
+if [ ! -f "$PDF" ]; then
+    echo "Error: $PDF not found — run scripts/fetch-resume.sh first" >&2
+    exit 1
+fi
+
+PAGES=$(pdfinfo "$PDF" | awk '/^Pages:/ { print $2 }')
+if [ -z "$PAGES" ] || [ "$PAGES" -lt 1 ]; then
+    echo "Error: could not determine page count of $PDF" >&2
+    exit 1
+fi
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+for p in $(seq 1 "$PAGES"); do
+    printf -v name "page-%02d.svg" "$p"
+    pdftocairo -svg -f "$p" -l "$p" "$PDF" "$OUT/$name"
+done
+
+pdftotext -layout "$PDF" "$OUT/resume.txt"
+
+echo "Rendered $PAGES page(s) to $OUT:"
+ls -la "$OUT"
+```
+
+`-f`/`-l` bound the page range, because `pdftocairo -svg` writes a single file and would otherwise emit only the first page.
+
+- [ ] **Step 2: Ignore the artifacts**
+
+Append to `.gitignore`:
+
+```
+/static/resume/
+```
+
+Confirm with `git status --short` that nothing under `static/resume/` is staged. The `.gitignore` already carries `/static/demos/reaction-diffusion/` for the wasm; this is the same pattern.
+
+- [ ] **Step 3: Run it and verify**
+
+```bash
+./scripts/render-resume.sh
+ls -la static/resume/
+head -3 static/resume/resume.txt
+gzip -c static/resume/page-01.svg | wc -c
+```
+
+Expected: one `page-01.svg`, a `resume.txt` beginning with "Paul Maxwell", and a gzipped SVG in the region of 69 KB. Record the actual sizes in your report.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/render-resume.sh .gitignore
+git commit -m "feat: render the resume PDF to vector SVG and text"
+```
+
+---
+
+### Task 2: Render the resume page from those artifacts
+
+**Files:**
+- Modify: `crates/site/src/pages/resume.rs`, `crates/site/src/build.rs`, `crates/site/src/theme.rs`
+
+**Interfaces:**
+- Consumes: `static/resume/page-*.svg` and `static/resume/resume.txt` (Task 1).
+- Produces: `pages::resume::render(site: &Site, pages: &[String], text: &str) -> Markup`, where `pages` holds rooted URLs such as `/resume/page-01.svg` in page order, and `text` is the extracted plain text. `build.rs` discovers the artifacts and passes them in.
+
+The page module stays a pure function of its inputs — filesystem discovery belongs in `build.rs`, which already owns that responsibility.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the test module in `crates/site/src/pages/resume.rs` with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pages() -> Vec<String> {
+        vec!["/resume/page-01.svg".to_string(), "/resume/page-02.svg".to_string()]
+    }
+
+    #[test]
+    fn resume_shows_one_image_per_page_in_order() {
+        let out = render(&crate::content::fixture_site(), &pages(), "Paul Maxwell").into_string();
+        let first = out.find("/resume/page-01.svg").expect("page 1 missing");
+        let second = out.find("/resume/page-02.svg").expect("page 2 missing");
+        assert!(first < second, "pages rendered out of order");
+        assert_eq!(out.matches("<img").count(), 2, "expected exactly one img per page");
+    }
+
+    #[test]
+    fn resume_keeps_the_pdf_download() {
+        let out = render(&crate::content::fixture_site(), &pages(), "text").into_string();
+        assert!(out.contains(&format!(r#"href="{RESUME_PDF}""#)), "download link missing");
+        assert!(out.contains("download"), "download attribute missing");
+    }
+
+    #[test]
+    fn resume_embeds_the_extracted_text_for_screen_readers() {
+        let out = render(&crate::content::fixture_site(), &pages(), "Aho-Corasick").into_string();
+        assert!(out.contains("visually-hidden"), "hidden text container missing");
+        assert!(out.contains("Aho-Corasick"), "extracted text not embedded");
+    }
+
+    #[test]
+    fn resume_without_rendered_pages_still_offers_the_download() {
+        let out = render(&crate::content::fixture_site(), &[], "").into_string();
+        assert!(out.contains(&format!(r#"href="{RESUME_PDF}""#)), "download link missing");
+        assert_eq!(out.matches("<img").count(), 0, "no pages should render no images");
+    }
+
+    #[test]
+    fn extracted_text_is_escaped_not_injected() {
+        let out = render(&crate::content::fixture_site(), &pages(), "a <script>x</script> b").into_string();
+        assert!(!out.contains("<script>x</script>"), "raw markup leaked from the PDF text");
+        assert!(out.contains("&lt;script&gt;"), "text should be HTML-escaped");
+    }
+}
+```
+
+That last test matters: the text comes from a PDF, and `maud` escapes interpolated values by default — this pins that nobody later "fixes" it with `PreEscaped`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p site resume`
+Expected: FAIL — `render` takes the wrong number of arguments.
+
+- [ ] **Step 3: Implement the page**
+
+Replace the body of `crates/site/src/pages/resume.rs` above the tests:
+
+```rust
+use crate::components::shell;
+use crate::content::Site;
+use crate::route::Route;
+use maud::{html, Markup};
+
+/// Published location of the PDF fetched from the private release.
+pub const RESUME_PDF: &str = "/assets/paul_maxwell_resume.pdf";
+
+/// Renders the resume as inline vector pages with a hidden text layer.
+///
+/// `pages` holds rooted URLs in page order; `text` is the plain-text
+/// extraction. With no pages — a local build that has not run
+/// `scripts/render-resume.sh` — the page degrades to the download link.
+pub fn render(site: &Site, pages: &[String], text: &str) -> Markup {
+    let main = html! {
+        h1 { "Resume" }
+        p .prose {
+            a href=(RESUME_PDF) download { "Download PDF" }
+        }
+
+        @for (i, page) in pages.iter().enumerate() {
+            img .resume-page src=(page) alt=(format!("Resume page {} of {}", i + 1, pages.len()));
+        }
+
+        @if !text.is_empty() {
+            div .visually-hidden { (text) }
+        }
+    };
+    shell::layout(site, Route::Resume, "Resume", main)
+}
+```
+
+- [ ] **Step 4: Style the pages**
+
+In `theme::stylesheet()`, replace nothing and add — remembering that every literal brace is doubled inside the `format!` raw string:
+
+```css
+.resume-page {{
+  display: block;
+  width: 100%;
+  max-width: 780px;
+  height: auto;
+  margin: calc(var(--space) * 3) 0;
+  border: 1px solid var(--rule);
+  background: #FFFFFF;
+}}
+.visually-hidden {{
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}}
+```
+
+The explicit white background is deliberate: the resume is a document with its own white page, and it must not become transparent over the dark theme's near-black paper.
+
+- [ ] **Step 5: Discover the artifacts in the build**
+
+In `build.rs`, before rendering routes, read the artifacts from `root`:
+
+```rust
+/// Finds the rendered resume pages and extracted text, if they exist.
+/// Returns rooted URLs in page order.
+fn resume_artifacts(root: &Path) -> Result<(Vec<String>, String)> {
+    let dir = root.join("static/resume");
+    if !dir.exists() {
+        return Ok((Vec::new(), String::new()));
+    }
+    let mut pages: Vec<String> = std::fs::read_dir(&dir)?
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.starts_with("page-") && n.ends_with(".svg"))
+        .map(|n| format!("/resume/{n}"))
+        .collect();
+    pages.sort();
+    let text = std::fs::read_to_string(dir.join("resume.txt")).unwrap_or_default();
+    Ok((pages, text))
+}
+```
+
+Sorting the zero-padded names gives page order, which is why Task 1 pads them.
+
+Then pass them into the `Route::Resume` arm, and add the strict check alongside the existing resume-PDF one:
+
+```rust
+    let (resume_pages, resume_text) = resume_artifacts(root)?;
+    if resume_pages.is_empty() {
+        let msg = "resume pages not rendered — run scripts/render-resume.sh";
+        if strict {
+            anyhow::bail!("{msg}");
+        }
+        eprintln!("warning: {msg} (non-strict build, continuing)");
+    }
+```
+
+- [ ] **Step 6: Add build tests**
+
+```rust
+    #[test]
+    fn build_embeds_the_rendered_resume_pages() {
+        let tmp = std::env::temp_dir().join("site-resume-test");
+        let _ = std::fs::remove_dir_all(&tmp);
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+
+        let html = std::fs::read_to_string(tmp.join("resume/index.html")).unwrap();
+        let (pages, _) = resume_artifacts(Path::new("../..")).unwrap();
+        for page in &pages {
+            assert!(html.contains(page.as_str()), "resume page {page} not referenced");
+        }
+        assert!(
+            html.contains("/assets/paul_maxwell_resume.pdf"),
+            "download link missing from the built page"
+        );
+        assert!(!html.contains("<object"), "the old PDF object embed should be gone");
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+```
+
+- [ ] **Step 7: Verify**
+
+```bash
+./scripts/render-resume.sh
+cargo test --all
+cargo clippy --all-targets -- -D warnings
+cargo run -p site -- --strict
+grep -o '<img[^>]*resume-page[^>]*>' dist/resume/index.html
+grep -c 'visually-hidden' dist/resume/index.html
+grep -c '<object' dist/resume/index.html      # expect 0
+ls -la dist/resume/
+```
+
+Then serve `dist/` and open `/resume/` in a browser. Confirm: the resume renders inline at full width with a hairline border, no browser PDF toolbar, the download link works, and it is legible in both themes. Report what you saw.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/site/src
+git commit -m "feat: embed the resume as inline vector pages with a hidden text layer"
+```
+
+---
+
+### Task 3: Build the artifacts in CI
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml`
+
+**Interfaces:**
+- Consumes: `scripts/render-resume.sh`.
+- Produces: a deployment containing the rendered resume.
+
+Without this, CI publishes a resume page whose images 404 — and no test catches it, because every test runs where the artifacts already exist locally. This is the same trap the wasm build had, and it gets the same explicit verification step.
+
+- [ ] **Step 1: Install poppler and render**
+
+In `.github/workflows/deploy.yml`, after the `Fetch resume` step and before `Build site`:
+
+```yaml
+    - name: Install poppler
+      run: sudo apt-get update && sudo apt-get install -y poppler-utils
+
+    - name: Render resume
+      run: ./scripts/render-resume.sh
+```
+
+It must follow `Fetch resume`, since the script needs the downloaded PDF, and precede `Build site`, since the generator copies `static/` into `dist/`.
+
+- [ ] **Step 2: Verify the artifacts shipped**
+
+Extend the existing `Verify wasm shipped` step, or add alongside it:
+
+```yaml
+    - name: Verify resume shipped
+      run: |
+        test -f dist/resume/page-01.svg
+        test -f dist/assets/paul_maxwell_resume.pdf
+        ls -la dist/resume/
+```
+
+- [ ] **Step 3: Validate and commit**
+
+```bash
+python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/deploy.yml')); [print(f'{i+1}. ' + (s.get('name') or s.get('uses'))) for i,s in enumerate(d['jobs']['build']['steps'])]"
+cargo test --all
+cargo clippy --all-targets -- -D warnings
+```
+
+Confirm by eye that `Fetch resume` → `Render resume` → `Build site` → `Verify resume shipped` appear in that order, and that the `deploy` job is unchanged.
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci: render the resume to SVG before building the site"
+```
+
+---
+
+## Definition of Done
+
+- `/resume/` shows the resume inline as crisp vector pages, with no browser PDF viewer chrome, on desktop and mobile alike.
+- The PDF download link still works and still points at the release asset.
+- The extracted text ships in a visually-hidden block, so screen readers and crawlers get real text where they previously got none.
+- The page is legible in both themes, with the document's white page preserved.
+- A local build without rendered artifacts warns and degrades to the download link; a strict build fails.
+- CI installs poppler, renders the pages, and fails the build if they are missing.
+- `cargo test --all` and `cargo clippy --all-targets -- -D warnings` pass; zero `#[allow(dead_code)]`.

--- a/scripts/render-resume.sh
+++ b/scripts/render-resume.sh
@@ -29,7 +29,7 @@ for p in $(seq 1 "$PAGES"); do
     pdftocairo -svg -f "$p" -l "$p" "$PDF" "$OUT/$name"
 done
 
-pdftotext -layout "$PDF" "$OUT/resume.txt"
+pdftotext -layout "$PDF" "$OUT/.resume.txt"
 
 echo "Rendered $PAGES page(s) to $OUT:"
 ls -la "$OUT"

--- a/scripts/render-resume.sh
+++ b/scripts/render-resume.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Renders the resume PDF to one SVG per page plus a plain-text extraction,
+# for inline display on /resume/. Run after scripts/fetch-resume.sh and
+# before `cargo run -p site`.
+#
+# Vector rather than raster: the SVG is ~69 KB gzipped and stays crisp at
+# any zoom, where a 150 dpi PNG is ~199 KB and goes soft.
+set -euo pipefail
+
+PDF=assets/paul_maxwell_resume.pdf
+OUT=static/resume
+
+if [ ! -f "$PDF" ]; then
+    echo "Error: $PDF not found — run scripts/fetch-resume.sh first" >&2
+    exit 1
+fi
+
+PAGES=$(pdfinfo "$PDF" | awk '/^Pages:/ { print $2 }')
+if [ -z "$PAGES" ] || [ "$PAGES" -lt 1 ]; then
+    echo "Error: could not determine page count of $PDF" >&2
+    exit 1
+fi
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+for p in $(seq 1 "$PAGES"); do
+    printf -v name "page-%02d.svg" "$p"
+    pdftocairo -svg -f "$p" -l "$p" "$PDF" "$OUT/$name"
+done
+
+pdftotext -layout "$PDF" "$OUT/resume.txt"
+
+echo "Rendered $PAGES page(s) to $OUT:"
+ls -la "$OUT"


### PR DESCRIPTION
Replaces the browser's PDF viewer on `/resume/` with the resume rendered inline as vector SVG, plus a hidden text layer.

## Why

The old `<object>` embed rendered in the browser's own PDF viewer — its toolbar and scrollbars inside the page design, a fixed `80vh` height unrelated to the page's real proportions, and **iOS Safari does not render PDFs inline at all**, so mobile visitors got a fallback apology where the resume should be.

## What changes

- `scripts/render-resume.sh` converts the release PDF to one SVG per page and extracts its text, via poppler.
- The generator discovers those artifacts and renders them inline. The image carries the SVG's own `width`/`height`, so the box is reserved before download and there is no layout shift.
- The extracted text ships in a visually-hidden block with a `Resume, text version` heading — screen readers and crawlers now get real text, where the `<object>` gave them none.
- **The PDF download link is unchanged.** It is what recruiters actually want.
- CI installs poppler, renders the pages, and greps the built HTML to confirm the images are actually referenced.

No change to the upstream private LaTeX repository.

## Vector, not raster

Measured on the real resume: SVG is **69 KB gzipped** and stays crisp at any zoom, against 199–329 KB for raster that degrades when zoomed. GitHub Pages serves SVG gzipped.

## Text quality

The extraction is normalised in Rust (not shell — BSD and GNU `sed` differ on `\b`, so dev and CI would diverge): LaTeX small-caps headings extract as `E XPERIENCE`, and a `ﬁ` ligature made "finishers" a different token to search engines. Both fixed, verified against the real resume with no false positives on `P-1 AI`, `GPA: 4.0`, `CFA`, `AWS`, `SNS/SQS`, or `NSA`.

## Known trade-off

`pdftocairo -svg` outlines glyphs, so the rendered page is no longer text-selectable. The download link is the mitigation.

90 tests, clippy clean at `-D warnings`, zero lint suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)