### PR TITLE
Tone down the site copy

### DIFF
--- a/content/site.toml
+++ b/content/site.toml
@@ -1,17 +1,16 @@
 name = "Paul Maxwell"
 location = "Washington, DC"
 role = "Lead Software Engineer / P-1 AI / 2025 —"
-lede = "I build the infrastructure that gets AI systems safely into production — deployment, observability, and the trust boundaries in between."
-bio = "Currently leading platform work at P-1 AI, where our engineering agent runs inside customers' own cloud environments so their data never has to leave. Before that: fraud prevention at Amazon, credit underwriting infrastructure at Ampla, distributed portfolio construction at BlackRock."
-credential = "NSA Codebreaker Challenge — one of 24 finishers out of more than 3,300 participants, 2023."
-description = "Paul Maxwell — Lead Software Engineer at P-1 AI, building the infrastructure that gets AI systems safely into production. Washington, DC."
+lede = "Software engineer. I build backend systems — platforms, data pipelines, and the services around them."
+bio = "Currently at P-1 AI, working on the platform behind Archie, an AI engineering agent. Before that: fraud detection at Amazon, credit underwriting at Ampla, portfolio analytics at BlackRock."
+description = "Paul Maxwell — software engineer at P-1 AI. Washington, DC."
 url = "https://paul-maxwell.com"
 projects_intro = "Selected work, most recent first. Longer write-ups and interactive demos are on the way."
 
 about = [
-  "I work at the layer where a system meets production and has to be trusted. That has meant bring-your-own-cloud deployment for an AI engineering agent, zero-trust gateways that keep real credentials out of agent sandboxes, real-time fraud detection, and underwriting controls that have to be auditable by people who are not engineers.",
-  "I hold a Master's in Computer Science from Georgia Tech and a BSE from the University of Michigan, and I am a CFA charterholder — an unusual pairing that turns out to be useful anywhere software meets capital.",
-  "Outside of work I do security challenges; I was one of 24 finishers of the NSA Codebreaker Challenge out of more than 3,300 participants in 2023.",
+  "I'm a software engineer in Washington, DC, currently at P-1 AI working on the platform behind an AI engineering agent — everything from how it deploys into customer clouds to the plugin and dataset infrastructure it runs on. Earlier I worked on fraud detection at Amazon, underwriting systems at Ampla, and portfolio tooling at BlackRock.",
+  "I have a master's in computer science from Georgia Tech, a BSE from Michigan, and a CFA charter.",
+  "In 2023 I was one of 24 finishers (of about 3,300) in the NSA Codebreaker Challenge.",
 ]
 
 [[work]]
@@ -30,7 +29,7 @@ summary = "A phantom-token pattern — agent code in ephemeral sandboxes holds o
 title = "Duplicate-Invoice Detection"
 org = "Amazon"
 year = "2024"
-summary = "Real-time service bursting to 500 TPS with pluggable rule and ML engines, inside a suite blocking $1B+ in fraud annually."
+summary = "Real-time duplicate-invoice detection (up to 500 TPS) with pluggable rule and ML engines, part of Amazon's fraud-prevention suite."
 
 [[work]]
 title = "EU Compliance Ingestion"

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -280,7 +280,6 @@ mod tests {
             role: "Tester".to_string(),
             lede: "Lede".to_string(),
             bio: "Bio".to_string(),
-            credential: "Credential".to_string(),
             description: "Description".to_string(),
             url: "https://example.com/?a=1&b=2".to_string(),
             projects_intro: "Intro".to_string(),

--- a/crates/site/src/content.rs
+++ b/crates/site/src/content.rs
@@ -11,7 +11,6 @@ pub struct Site {
     /// One sentence. The only line most visitors will read.
     pub lede: String,
     pub bio: String,
-    pub credential: String,
     /// Meta/OG description.
     pub description: String,
     /// Canonical base URL, no trailing slash.
@@ -81,7 +80,6 @@ location = "Y"
 role = "Z"
 lede = "L"
 bio = "B"
-credential = "C"
 projects_intro = "P"
 about = []
 surprise = "should not parse"
@@ -123,7 +121,6 @@ location = "Y"
 role = "Z"
 lede = "L"
 bio = "B"
-credential = "C"
 description = "D"
 url = "https://example.com"
 projects_intro = "P"

--- a/crates/site/src/pages/about.rs
+++ b/crates/site/src/pages/about.rs
@@ -23,7 +23,8 @@ mod tests {
         let site = Site::load(Path::new("../../content/site.toml")).unwrap();
         let out = render(&site).into_string();
         assert_eq!(out.matches("<p class=\"prose\">").count(), site.about.len());
-        assert!(out.contains("CFA charterholder"), "CFA belongs on About");
+        assert!(out.contains("CFA charter"), "CFA belongs on About");
+        assert!(out.contains("24 finishers"), "NSA line belongs on About");
         assert!(out.contains(r#"href="/about/" aria-current="page""#));
     }
 }

--- a/crates/site/src/pages/index.rs
+++ b/crates/site/src/pages/index.rs
@@ -21,8 +21,6 @@ pub fn render(site: &Site) -> Markup {
             span .mono { (format!("{:02}", site.work.len())) }
         }
         (work_list(&site.work))
-
-        p .prose style="margin-top:2rem" { (site.credential) }
     };
     shell::layout(site, Route::Index, "Index", main)
 }
@@ -37,10 +35,9 @@ mod tests {
         let site = Site::load(Path::new("../../content/site.toml")).unwrap();
         let out = render(&site).into_string();
         assert!(out.contains("Paul"), "name missing");
-        assert!(out.contains("trust boundaries in between"), "lede missing");
+        assert!(out.contains("backend systems"), "lede missing");
         assert!(out.contains("Selected Work"));
         assert!(out.contains("Archie BYOC Platform"));
-        assert!(out.contains("3,300"), "credential line missing");
         assert!(out.contains(r#"aria-current="page""#));
     }
 }


### PR DESCRIPTION
Owner-reviewed copy revision: the previous text narrated its author — a thesis statement about "the layer where a system meets production", a coined slogan ("anywhere software meets capital"), and the NSA Codebreaker result appearing twice, including as a standalone homepage trophy line.

The replacement states the same facts plainly. The NSA line now appears once, in About. The homepage `credential` field is removed from the content model along with its rendering and tests. One project card drops a team-level "$1B+" stat.

Copy approved verbatim by the owner. 67 tests, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)