### PR TITLE
Add GitHub and LinkedIn links to the About page

### DIFF
--- a/content/site.toml
+++ b/content/site.toml
@@ -5,6 +5,8 @@ lede = "Software engineer. I build backend systems — platforms, data pipelines
 bio = "Currently at P-1 AI, working on the platform behind Archie, an AI engineering agent. Before that: fraud detection at Amazon, credit underwriting at Ampla, portfolio analytics at BlackRock."
 description = "Paul Maxwell — software engineer at P-1 AI. Washington, DC."
 url = "https://paul-maxwell.com"
+github = "https://github.com/maxwellpaulm"
+linkedin = "https://www.linkedin.com/in/maxwellpaulm"
 projects_intro = "Selected work, most recent first. Longer write-ups and interactive demos are on the way."
 
 about = [

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -282,6 +282,8 @@ mod tests {
             bio: "Bio".to_string(),
             description: "Description".to_string(),
             url: "https://example.com/?a=1&b=2".to_string(),
+            github: "https://github.com/example".to_string(),
+            linkedin: "https://www.linkedin.com/in/example".to_string(),
             projects_intro: "Intro".to_string(),
             about: vec![],
             work: vec![],

--- a/crates/site/src/content.rs
+++ b/crates/site/src/content.rs
@@ -15,6 +15,8 @@ pub struct Site {
     pub description: String,
     /// Canonical base URL, no trailing slash.
     pub url: String,
+    pub github: String,
+    pub linkedin: String,
     pub projects_intro: String,
     pub about: Vec<String>,
     #[serde(default)]
@@ -70,6 +72,18 @@ mod tests {
         assert_eq!(site.location, "Washington, DC");
         assert!(!site.work.is_empty(), "expected selected work entries");
         assert!(site.lede.len() < 160, "lede should stay a single sentence");
+        assert!(!site.github.is_empty(), "github must be set");
+        assert!(!site.linkedin.is_empty(), "linkedin must be set");
+        assert!(
+            site.github.starts_with("https://"),
+            "github should be a full URL: {}",
+            site.github
+        );
+        assert!(
+            site.linkedin.starts_with("https://"),
+            "linkedin should be a full URL: {}",
+            site.linkedin
+        );
     }
 
     #[test]
@@ -123,6 +137,8 @@ lede = "L"
 bio = "B"
 description = "D"
 url = "https://example.com"
+github = "https://github.com/example"
+linkedin = "https://www.linkedin.com/in/example"
 projects_intro = "P"
 about = []
 

--- a/crates/site/src/pages/about.rs
+++ b/crates/site/src/pages/about.rs
@@ -9,6 +9,12 @@ pub fn render(site: &Site) -> Markup {
         @for paragraph in &site.about {
             p .prose { (paragraph) }
         }
+        p .prose {
+            "Elsewhere: "
+            a href=(site.github) rel="me" { "GitHub" }
+            " · "
+            a href=(site.linkedin) rel="me" { "LinkedIn" }
+        }
     };
     shell::layout(site, Route::About, "About", main)
 }
@@ -22,9 +28,32 @@ mod tests {
     fn about_renders_every_paragraph_and_mentions_the_cfa() {
         let site = Site::load(Path::new("../../content/site.toml")).unwrap();
         let out = render(&site).into_string();
-        assert_eq!(out.matches("<p class=\"prose\">").count(), site.about.len());
+        // One <p class="prose"> per about paragraph, plus the links line.
+        assert_eq!(out.matches("<p class=\"prose\">").count(), site.about.len() + 1);
         assert!(out.contains("CFA charter"), "CFA belongs on About");
         assert!(out.contains("24 finishers"), "NSA line belongs on About");
         assert!(out.contains(r#"href="/about/" aria-current="page""#));
+    }
+
+    #[test]
+    fn about_links_to_github_and_linkedin() {
+        let site = Site::load(Path::new("../../content/site.toml")).unwrap();
+        let out = render(&site).into_string();
+        assert!(
+            out.contains(r#"href="https://github.com/maxwellpaulm""#),
+            "missing github href: {out}"
+        );
+        assert!(
+            out.contains(r#"href="https://www.linkedin.com/in/maxwellpaulm""#),
+            "missing linkedin href: {out}"
+        );
+        assert!(out.contains(">GitHub<"), "expected visible link text \"GitHub\": {out}");
+        assert!(out.contains(">LinkedIn<"), "expected visible link text \"LinkedIn\": {out}");
+        assert!(out.contains(r#"rel="me""#), "profile links should carry rel=\"me\": {out}");
+        assert_eq!(
+            out.matches(r#"rel="me""#).count(),
+            2,
+            "both github and linkedin links should carry rel=\"me\": {out}"
+        );
     }
 }


### PR DESCRIPTION
Adds an "Elsewhere: GitHub · LinkedIn" line to the end of the About page, with `rel="me"` identity markers. Handles come from `content/site.toml` as new required fields.

68 tests, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)