### PR TITLE
Add GitHub and LinkedIn links to the rail footer

### DIFF
--- a/crates/site/src/components/rail.rs
+++ b/crates/site/src/components/rail.rs
@@ -20,6 +20,10 @@ pub fn rail(site: &Site, current: Option<Route>) -> Markup {
             }
             div .rail-foot {
                 div .mono { (site.location) }
+                div .rail-links {
+                    a href=(site.github) rel="me" { "GitHub" }
+                    a href=(site.linkedin) rel="me" { "LinkedIn" }
+                }
                 button type="button" .theme-toggle id="theme-toggle" aria-label="Toggle dark mode" aria-pressed="false" {
                     "Dark"
                 }
@@ -85,6 +89,30 @@ mod tests {
     fn rail_shows_location() {
         let out = rail(&site(), Some(Route::Index)).into_string();
         assert!(out.contains("Washington, DC"));
+    }
+
+    #[test]
+    fn rail_links_to_github_and_linkedin() {
+        let out = rail(&site(), Some(Route::Index)).into_string();
+        assert!(
+            out.contains(r#"<div class="rail-links">"#),
+            "missing rail-links wrapper: {out}"
+        );
+        assert!(
+            out.contains(r#"href="https://github.com/maxwellpaulm""#),
+            "missing github href: {out}"
+        );
+        assert!(
+            out.contains(r#"href="https://www.linkedin.com/in/maxwellpaulm""#),
+            "missing linkedin href: {out}"
+        );
+        assert!(out.contains(">GitHub<"), "expected visible link text \"GitHub\": {out}");
+        assert!(out.contains(">LinkedIn<"), "expected visible link text \"LinkedIn\": {out}");
+        assert_eq!(
+            out.matches(r#"rel="me""#).count(),
+            2,
+            "both github and linkedin links should carry rel=\"me\": {out}"
+        );
     }
 
     #[test]

--- a/crates/site/src/pages/about.rs
+++ b/crates/site/src/pages/about.rs
@@ -52,8 +52,8 @@ mod tests {
         assert!(out.contains(r#"rel="me""#), "profile links should carry rel=\"me\": {out}");
         assert_eq!(
             out.matches(r#"rel="me""#).count(),
-            2,
-            "both github and linkedin links should carry rel=\"me\": {out}"
+            4,
+            "both the Elsewhere line and the site-wide rail should carry two rel=\"me\" links each: {out}"
         );
     }
 }

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -138,6 +138,9 @@ a:hover {{ text-decoration: underline; }}
 .rail nav a[aria-current="page"] {{ color: var(--ink); font-weight: 500; }}
 .rail nav a[aria-current="page"]::before {{ content: "— "; color: var(--accent); }}
 .rail-foot {{ margin-top: auto; }}
+.rail-links {{ display: flex; flex-direction: column; gap: 4px; margin-top: calc(var(--space) * 1.5); }}
+.rail-links a {{ font-size: 12px; color: var(--muted); transition: color var(--motion) ease; }}
+.rail-links a:hover {{ color: var(--ink); text-decoration: none; }}
 .theme-toggle {{
   margin-top: calc(var(--space) * 1.5);
   font-family: var(--font-mono);
@@ -198,6 +201,7 @@ h2 {{ font-size: 24px; letter-spacing: -0.02em; font-weight: 600; }}
   }}
   .rail nav {{ flex-direction: row; gap: calc(var(--space) * 2); flex-wrap: wrap; }}
   .rail-foot {{ margin-top: 0; }}
+  .rail-links {{ flex-direction: row; gap: calc(var(--space) * 1.5); margin-top: 0; }}
   main {{ padding: calc(var(--space) * 4) calc(var(--space) * 2.5); }}
   h1 {{ font-size: 38px; }}
   .item {{ grid-template-columns: 1fr; gap: 4px; }}
@@ -267,6 +271,18 @@ mod tests {
         // this stylesheet.
         let css = stylesheet();
         assert!(css.contains(".resume-page {"), "stylesheet missing .resume-page: {css}");
+    }
+
+    #[test]
+    fn rail_links_class_used_in_markup_is_defined_here() {
+        // components/rail.rs writes `.rail-links` with nothing tying it to
+        // this stylesheet, including the collapsed-top-bar row layout.
+        let css = stylesheet();
+        assert!(css.contains(".rail-links {"), "stylesheet missing .rail-links: {css}");
+        assert!(
+            css.contains(".rail-links { flex-direction: row;"),
+            "stylesheet missing the collapsed top-bar .rail-links row variant: {css}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Site-wide profile links under the location line in the rail footer, muted like the rail's own nav (accent would outshout the navigation), brightening to ink on hover. Horizontal layout in the collapsed mobile top bar.

70 tests, clippy clean.

Note: verification surfaced a pre-existing `.rail-foot` overflow below ~400px viewport width, present on master before this change — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)