### PR TITLE
Add longer project write-ups to the Projects page

### DIFF
--- a/content/site.toml
+++ b/content/site.toml
@@ -20,27 +20,32 @@ title = "Archie BYOC Platform"
 org = "P-1 AI"
 year = "2025"
 summary = "Deploys an engineering AI agent into customer-controlled cloud; each install assembles from independently versioned components."
+detail = "P-1's engineering agent runs inside customer cloud environments rather than ours. Each install is assembled from independently versioned components, so deployments can differ per customer without forking the platform."
 
 [[work]]
 title = "Zero-Trust Agent Gateway"
 org = "P-1 AI"
 year = "2025"
 summary = "A phantom-token pattern — agent code in ephemeral sandboxes holds only opaque, request-scoped tokens; the gateway keeps every real credential."
+detail = "Agent-written code runs in ephemeral sandboxes and never holds real credentials. Sandboxes get opaque, request-scoped tokens; the gateway holds the real ones and enforces authentication, authorization, scoping, and rate limits."
 
 [[work]]
 title = "Duplicate-Invoice Detection"
 org = "Amazon"
 year = "2024"
 summary = "Real-time duplicate-invoice detection (up to 500 TPS) with pluggable rule and ML engines, part of Amazon's fraud-prevention suite."
+detail = "Real-time detection service handling bursts up to 500 TPS, with rule-based and ML engines behind a common interface so new detectors ship without touching the pipeline. Runs on Lambda, SageMaker, and OpenSearch."
 
 [[work]]
 title = "EU Compliance Ingestion"
 org = "Amazon"
 year = "2024"
 summary = "Processes roughly one billion book titles per year, extracting required metadata and storing compliance artifacts at 500 TPS."
+detail = "Pipeline on Fargate, SNS/SQS, and Lambda processing roughly a billion book titles a year — extracting required metadata and storing compliance artifacts at up to 500 TPS."
 
 [[work]]
 title = "Transaction Tagging Engine"
 org = "Ampla"
 year = "2022"
 summary = "Re-implemented with Aho–Corasick; runtime went from hours to 90 seconds."
+detail = "Re-implemented Ampla's transaction tagging around Aho–Corasick string matching, taking runtime from hours to 90 seconds."

--- a/crates/site/src/components/work.rs
+++ b/crates/site/src/components/work.rs
@@ -15,6 +15,26 @@ pub fn work_list(items: &[Work]) -> Markup {
     }
 }
 
+/// Same as `work_list`, plus a longer write-up paragraph per item when
+/// `detail` is set. Used on the Projects page only — the homepage keeps
+/// the short cards from `work_list`.
+pub fn work_list_detailed(items: &[Work]) -> Markup {
+    html! {
+        @for item in items {
+            div .item {
+                div {
+                    h3 { (item.title) " " span .org { "· " (item.org) } }
+                    p { (item.summary) }
+                    @if !item.detail.is_empty() {
+                        p .work-detail { (item.detail) }
+                    }
+                }
+                div .mono .year { (item.year) }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -25,6 +45,7 @@ mod tests {
             org: "P-1 AI".into(),
             year: "2025".into(),
             summary: "Phantom-token pattern.".into(),
+            detail: String::new(),
         }]
     }
 
@@ -42,5 +63,20 @@ mod tests {
     #[test]
     fn empty_input_renders_nothing_rather_than_an_empty_shell() {
         assert_eq!(work_list(&[]).into_string(), "");
+    }
+
+    #[test]
+    fn detailed_variant_renders_the_detail_paragraph() {
+        let mut item = items().remove(0);
+        item.detail = "The gateway holds every real credential.".into();
+        let out = work_list_detailed(&[item]).into_string();
+        assert!(out.contains(r#"class="work-detail""#));
+        assert!(out.contains("The gateway holds every real credential."));
+    }
+
+    #[test]
+    fn detailed_variant_omits_the_paragraph_when_detail_is_empty() {
+        let out = work_list_detailed(&items()).into_string();
+        assert!(!out.contains("work-detail"));
     }
 }

--- a/crates/site/src/content.rs
+++ b/crates/site/src/content.rs
@@ -30,6 +30,8 @@ pub struct Work {
     pub org: String,
     pub year: String,
     pub summary: String,
+    #[serde(default)]
+    pub detail: String,
 }
 
 impl Site {

--- a/crates/site/src/pages/index.rs
+++ b/crates/site/src/pages/index.rs
@@ -40,4 +40,14 @@ mod tests {
         assert!(out.contains("Archie BYOC Platform"));
         assert!(out.contains(r#"aria-current="page""#));
     }
+
+    #[test]
+    fn index_does_not_leak_the_projects_page_writeups() {
+        let site = Site::load(Path::new("../../content/site.toml")).unwrap();
+        let out = render(&site).into_string();
+        assert!(
+            !out.contains("without forking the platform"),
+            "detail copy leaked onto the homepage"
+        );
+    }
 }

--- a/crates/site/src/pages/projects.rs
+++ b/crates/site/src/pages/projects.rs
@@ -1,4 +1,4 @@
-use crate::components::{shell, work::work_list};
+use crate::components::{shell, work::work_list_detailed};
 use crate::content::Site;
 use crate::route::Route;
 use maud::{html, Markup};
@@ -11,7 +11,7 @@ pub fn render(site: &Site) -> Markup {
             span .mono { "Selected Work" }
             span .mono { (format!("{:02}", site.work.len())) }
         }
-        (work_list(&site.work))
+        (work_list_detailed(&site.work))
     };
     shell::layout(site, Route::Projects, "Projects", main)
 }
@@ -30,5 +30,19 @@ mod tests {
         for banned in ["Project 1", "Description of your", "goes here", "Lorem"] {
             assert!(!out.contains(banned), "placeholder copy found: {banned}");
         }
+    }
+
+    #[test]
+    fn projects_page_renders_the_detail_writeups() {
+        let site = fixture_site();
+        let out = render(&site).into_string();
+        assert!(out.contains("forking the platform"), "Archie detail missing");
+        assert!(out.contains("request-scoped tokens"), "Gateway detail missing");
+        assert!(
+            out.contains("without touching the pipeline"),
+            "Duplicate-invoice detail missing"
+        );
+        assert!(out.contains("billion book titles"), "EU compliance detail missing");
+        assert!(out.contains("hours to 90 seconds"), "Transaction tagging detail missing");
     }
 }

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -180,6 +180,7 @@ h2 {{ font-size: 24px; letter-spacing: -0.02em; font-weight: 600; }}
 .item p {{ margin: 0; font-size: 13.5px; line-height: 1.55; color: var(--muted); max-width: var(--measure); }}
 .item .year {{ text-align: right; }}
 .org {{ color: var(--accent); }}
+.work-detail {{ font-size: 13.5px; line-height: 1.6; color: var(--ink); max-width: var(--measure); margin: 6px 0 0; }}
 
 .resume-page {{
   display: block;
@@ -271,6 +272,14 @@ mod tests {
         // this stylesheet.
         let css = stylesheet();
         assert!(css.contains(".resume-page {"), "stylesheet missing .resume-page: {css}");
+    }
+
+    #[test]
+    fn work_detail_class_used_in_markup_is_defined_here() {
+        // components/work.rs's work_list_detailed writes `.work-detail` with
+        // nothing tying it to this stylesheet.
+        let css = stylesheet();
+        assert!(css.contains(".work-detail {"), "stylesheet missing .work-detail: {css}");
     }
 
     #[test]


### PR DESCRIPTION
Each project card on `/projects/` gains a short factual paragraph (owner-approved verbatim), rendered via an optional `detail` field on work entries. Homepage cards unchanged — verified zero leakage.

76 tests, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)