### PR TITLE
Aho-Corasick visualizer demo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,9 @@ jobs:
         test -f dist/demos/reaction-diffusion/reaction_diffusion_bg.wasm
         test -f dist/demos/reaction-diffusion/reaction_diffusion.js
         ls -la dist/demos/reaction-diffusion/
+        test -f dist/demos/aho-corasick/aho_corasick_demo_bg.wasm
+        test -f dist/demos/aho-corasick/aho_corasick_demo.js
+        grep -q 'aho-loader.js' dist/demos/aho-corasick/index.html
 
     - name: Verify resume shipped
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
         ls -la dist/demos/reaction-diffusion/
         test -f dist/demos/aho-corasick/aho_corasick_demo_bg.wasm
         test -f dist/demos/aho-corasick/aho_corasick_demo.js
-        grep -q 'aho-loader.js' dist/demos/aho-corasick/index.html
+        grep -q 'src="/demos/aho-loader.js"' dist/demos/aho-corasick/index.html
 
     - name: Verify resume shipped
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ set_env.sh
 /assets/paul_maxwell_resume.pdf
 .superpowers/
 /static/demos/reaction-diffusion/
+/static/demos/aho-corasick/
 /static/resume/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "aho-corasick-demo"
+version = "0.1.0"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/site", "crates/demos/reaction-diffusion"]
+members = ["crates/site", "crates/demos/reaction-diffusion", "crates/demos/aho-corasick-demo"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/demos/aho-corasick-demo/Cargo.toml
+++ b/crates/demos/aho-corasick-demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "aho-corasick-demo"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.127"

--- a/crates/demos/aho-corasick-demo/src/automaton.rs
+++ b/crates/demos/aho-corasick-demo/src/automaton.rs
@@ -12,7 +12,6 @@ pub enum BuildError {
 const MAX_PATTERNS: usize = 8;
 const MAX_PATTERN_LEN: usize = 10;
 
-#[derive(Debug, PartialEq)]
 struct Node {
     label: u8,
     parent: usize,
@@ -22,7 +21,6 @@ struct Node {
     outputs: Vec<usize>,
 }
 
-#[derive(Debug, PartialEq)]
 pub struct Automaton {
     nodes: Vec<Node>,
 }
@@ -307,6 +305,9 @@ mod tests {
             found.extend(c.step(b).matches);
         }
         assert_eq!(found, vec![(0, 2)]);
-        assert_eq!(Automaton::build(&["123"]), Err(BuildError::EmptyPattern));
+        assert!(matches!(
+            Automaton::build(&["123"]),
+            Err(BuildError::EmptyPattern)
+        ));
     }
 }

--- a/crates/demos/aho-corasick-demo/src/automaton.rs
+++ b/crates/demos/aho-corasick-demo/src/automaton.rs
@@ -9,8 +9,36 @@ pub enum BuildError {
     PatternTooLong,
 }
 
+impl std::fmt::Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BuildError::NoPatterns => write!(f, "no patterns given"),
+            BuildError::TooManyPatterns => write!(f, "too many patterns (max {MAX_PATTERNS})"),
+            BuildError::EmptyPattern => {
+                write!(f, "a pattern has no letters left after removing non-letters")
+            }
+            BuildError::PatternTooLong => {
+                write!(f, "pattern too long (max {MAX_PATTERN_LEN} letters)")
+            }
+        }
+    }
+}
+
 const MAX_PATTERNS: usize = 8;
 const MAX_PATTERN_LEN: usize = 10;
+
+/// Strips non-alphabetic bytes and lowercases the rest. `Automaton::build`
+/// folds every pattern this way before inserting it into the trie, so
+/// anything that needs to reason about a pattern's on-trie length (the
+/// wasm wrapper, converting match end positions to text ranges) must fold
+/// with this exact function or its lengths will disagree with the trie's.
+pub fn fold(pattern: &str) -> Vec<u8> {
+    pattern
+        .bytes()
+        .filter(|b| b.is_ascii_alphabetic())
+        .map(|b| b.to_ascii_lowercase())
+        .collect()
+}
 
 struct Node {
     label: u8,
@@ -43,11 +71,7 @@ impl Automaton {
         }];
 
         for (pi, pat) in patterns.iter().enumerate() {
-            let folded: Vec<u8> = pat
-                .bytes()
-                .filter(|b| b.is_ascii_alphabetic())
-                .map(|b| b.to_ascii_lowercase())
-                .collect();
+            let folded = fold(pat);
             if folded.is_empty() {
                 return Err(BuildError::EmptyPattern);
             }
@@ -124,20 +148,54 @@ impl Automaton {
     fn child(&self, s: usize, b: u8) -> Option<usize> {
         self.nodes[s].children.iter().copied().find(|&c| self.nodes[c].label == b)
     }
+
+    /// Advances from `state` on `byte`, taking as many failure hops as the
+    /// trie requires. Non-alphabetic bytes reset to the root (word
+    /// boundary) with no hops. Returns the hops taken (each an intermediate
+    /// state landed on while backing off) and the resulting state.
+    ///
+    /// This is the one place the failure-hop stepping logic lives: both
+    /// `Cursor::step` (native tests) and the wasm wrapper (which cannot
+    /// hold a borrowing `Cursor<'a>` inside a `#[wasm_bindgen]` struct)
+    /// drive the automaton through this method instead of duplicating it.
+    pub fn advance(&self, state: usize, byte: u8) -> (Vec<usize>, usize) {
+        if !byte.is_ascii_alphabetic() {
+            return (Vec::new(), 0);
+        }
+        let b = byte.to_ascii_lowercase();
+        let mut state = state;
+        let mut hops = Vec::new();
+        while self.child(state, b).is_none() && state != 0 {
+            state = self.fail(state);
+            hops.push(state);
+        }
+        if let Some(next) = self.child(state, b) {
+            state = next;
+        }
+        (hops, state)
+    }
 }
 
+// `Cursor` predates `Automaton::advance` (see its doc comment): it now
+// exists solely to exercise `advance` and `outputs` natively without the
+// wasm wrapper's flattened-array bookkeeping. Nothing outside tests
+// constructs one — the wrapper drives the automaton directly — so it is
+// `cfg(test)`-only rather than dead weight in the shipped crate.
+#[cfg(test)]
 pub struct StepEvent {
     pub hops: Vec<usize>,
     pub state: usize,
     pub matches: Vec<(usize, usize)>,
 }
 
+#[cfg(test)]
 pub struct Cursor<'a> {
     automaton: &'a Automaton,
     state: usize,
     pos: usize,
 }
 
+#[cfg(test)]
 impl<'a> Cursor<'a> {
     pub fn new(automaton: &'a Automaton) -> Self {
         Cursor { automaton, state: 0, pos: 0 }
@@ -146,26 +204,10 @@ impl<'a> Cursor<'a> {
     /// Advance one byte. Non-alphabetic bytes reset to root (word boundary).
     pub fn step(&mut self, byte: u8) -> StepEvent {
         self.pos += 1;
-        if !byte.is_ascii_alphabetic() {
-            self.state = 0;
-            return StepEvent { hops: Vec::new(), state: 0, matches: Vec::new() };
-        }
-        let b = byte.to_ascii_lowercase();
-        let mut hops = Vec::new();
-        while self.automaton.child(self.state, b).is_none() && self.state != 0 {
-            self.state = self.automaton.fail(self.state);
-            hops.push(self.state);
-        }
-        if let Some(next) = self.automaton.child(self.state, b) {
-            self.state = next;
-        }
-        let matches = self
-            .automaton
-            .outputs(self.state)
-            .iter()
-            .map(|&pi| (pi, self.pos))
-            .collect();
-        StepEvent { hops, state: self.state, matches }
+        let (hops, state) = self.automaton.advance(self.state, byte);
+        self.state = state;
+        let matches = self.automaton.outputs(state).iter().map(|&pi| (pi, self.pos)).collect();
+        StepEvent { hops, state, matches }
     }
 }
 
@@ -309,5 +351,50 @@ mod tests {
             Automaton::build(&["123"]),
             Err(BuildError::EmptyPattern)
         ));
+    }
+
+    #[test]
+    fn advance_matches_the_cursor_it_replaced() {
+        // `Cursor::step` now delegates its failure-hop logic to
+        // `Automaton::advance`; walk both in lockstep over the textbook
+        // hop-producing case and check they never diverge.
+        let a = textbook();
+        let mut cursor = Cursor::new(&a);
+        let mut state = 0usize;
+        for b in "ushers".bytes() {
+            let event = cursor.step(b);
+            let (hops, next_state) = a.advance(state, b);
+            assert_eq!(hops, event.hops);
+            assert_eq!(next_state, event.state);
+            state = next_state;
+        }
+    }
+
+    #[test]
+    fn build_error_messages_are_readable() {
+        // The wasm wrapper relays `BuildError::to_string()` verbatim as the
+        // JS exception message, so its wording is pinned here rather than
+        // only through the wrapper (which can't run outside a wasm target;
+        // see `lib.rs`'s test module).
+        assert_eq!(BuildError::NoPatterns.to_string(), "no patterns given");
+        assert_eq!(
+            BuildError::TooManyPatterns.to_string(),
+            "too many patterns (max 8)"
+        );
+        assert_eq!(
+            BuildError::PatternTooLong.to_string(),
+            "pattern too long (max 10 letters)"
+        );
+        // `Automaton` has no `Debug` impl, so `Result::unwrap_err` (which
+        // requires the `Ok` side to be `Debug`) isn't available here; match
+        // instead, as the wrapper's `.map_err` effectively does.
+        let nine = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+        let Err(err) = Automaton::build(&nine) else { panic!("9 patterns should be rejected") };
+        assert_eq!(err.to_string(), "too many patterns (max 8)");
+        let Err(err) = Automaton::build(&["123"]) else { panic!("digits-only pattern should be rejected") };
+        assert_eq!(
+            err.to_string(),
+            "a pattern has no letters left after removing non-letters"
+        );
     }
 }

--- a/crates/demos/aho-corasick-demo/src/automaton.rs
+++ b/crates/demos/aho-corasick-demo/src/automaton.rs
@@ -1,0 +1,273 @@
+//! Aho–Corasick automaton, built from scratch for the visualizer.
+//! Deliberately free of wasm so the algorithm is tested natively.
+
+#[derive(Debug, PartialEq)]
+pub enum BuildError {
+    NoPatterns,
+    TooManyPatterns,
+    EmptyPattern,
+    PatternTooLong,
+}
+
+const MAX_PATTERNS: usize = 8;
+const MAX_PATTERN_LEN: usize = 10;
+
+struct Node {
+    label: u8,
+    parent: usize,
+    depth: usize,
+    children: Vec<usize>, // indices into nodes; labels are unique per parent
+    fail: usize,
+    outputs: Vec<usize>,
+}
+
+pub struct Automaton {
+    nodes: Vec<Node>,
+}
+
+impl Automaton {
+    pub fn build(patterns: &[&str]) -> Result<Self, BuildError> {
+        if patterns.is_empty() {
+            return Err(BuildError::NoPatterns);
+        }
+        if patterns.len() > MAX_PATTERNS {
+            return Err(BuildError::TooManyPatterns);
+        }
+        let mut nodes = vec![Node {
+            label: 0,
+            parent: 0,
+            depth: 0,
+            children: Vec::new(),
+            fail: 0,
+            outputs: Vec::new(),
+        }];
+
+        for (pi, pat) in patterns.iter().enumerate() {
+            let folded: Vec<u8> = pat
+                .bytes()
+                .filter(|b| b.is_ascii_alphabetic())
+                .map(|b| b.to_ascii_lowercase())
+                .collect();
+            if folded.is_empty() {
+                return Err(BuildError::EmptyPattern);
+            }
+            if folded.len() > MAX_PATTERN_LEN {
+                return Err(BuildError::PatternTooLong);
+            }
+            let mut s = 0usize;
+            for &b in &folded {
+                s = match nodes[s].children.iter().copied().find(|&c| nodes[c].label == b) {
+                    Some(c) => c,
+                    None => {
+                        let id = nodes.len();
+                        let depth = nodes[s].depth + 1;
+                        nodes.push(Node {
+                            label: b,
+                            parent: s,
+                            depth,
+                            children: Vec::new(),
+                            fail: 0,
+                            outputs: Vec::new(),
+                        });
+                        nodes[s].children.push(id);
+                        id
+                    }
+                };
+            }
+            nodes[s].outputs.push(pi);
+        }
+
+        // BFS failure links; merge suffix outputs as we go.
+        let mut queue: std::collections::VecDeque<usize> = nodes[0].children.clone().into();
+        while let Some(u) = queue.pop_front() {
+            for c in nodes[u].children.clone() {
+                queue.push_back(c);
+                let label = nodes[c].label;
+                let mut f = nodes[u].fail;
+                let fail_of_c = loop {
+                    if let Some(t) = nodes[f].children.iter().copied().find(|&t| nodes[t].label == label) {
+                        if t != c {
+                            break t;
+                        }
+                    }
+                    if f == 0 {
+                        break 0;
+                    }
+                    f = nodes[f].fail;
+                };
+                nodes[c].fail = fail_of_c;
+                let inherited = nodes[fail_of_c].outputs.clone();
+                nodes[c].outputs.extend(inherited);
+            }
+        }
+        Ok(Automaton { nodes })
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+    pub fn label(&self, s: usize) -> u8 {
+        self.nodes[s].label
+    }
+    pub fn parent(&self, s: usize) -> usize {
+        self.nodes[s].parent
+    }
+    pub fn fail(&self, s: usize) -> usize {
+        self.nodes[s].fail
+    }
+    pub fn depth(&self, s: usize) -> usize {
+        self.nodes[s].depth
+    }
+    pub fn outputs(&self, s: usize) -> &[usize] {
+        &self.nodes[s].outputs
+    }
+
+    fn child(&self, s: usize, b: u8) -> Option<usize> {
+        self.nodes[s].children.iter().copied().find(|&c| self.nodes[c].label == b)
+    }
+}
+
+pub struct StepEvent {
+    pub hops: Vec<usize>,
+    pub state: usize,
+    pub matches: Vec<(usize, usize)>,
+}
+
+pub struct Cursor<'a> {
+    automaton: &'a Automaton,
+    state: usize,
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    pub fn new(automaton: &'a Automaton) -> Self {
+        Cursor { automaton, state: 0, pos: 0 }
+    }
+
+    /// Advance one byte. Non-alphabetic bytes reset to root (word boundary).
+    pub fn step(&mut self, byte: u8) -> StepEvent {
+        self.pos += 1;
+        if !byte.is_ascii_alphabetic() {
+            self.state = 0;
+            return StepEvent { hops: Vec::new(), state: 0, matches: Vec::new() };
+        }
+        let b = byte.to_ascii_lowercase();
+        let mut hops = Vec::new();
+        while self.automaton.child(self.state, b).is_none() && self.state != 0 {
+            self.state = self.automaton.fail(self.state);
+            hops.push(self.state);
+        }
+        if let Some(next) = self.automaton.child(self.state, b) {
+            self.state = next;
+        }
+        let matches = self
+            .automaton
+            .outputs(self.state)
+            .iter()
+            .map(|&pi| (pi, self.pos))
+            .collect();
+        StepEvent { hops, state: self.state, matches }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn textbook() -> Automaton {
+        Automaton::build(&["he", "she", "his", "hers"]).unwrap()
+    }
+
+    /// Walks the trie from the root along `word`, returning the state.
+    fn state_for(a: &Automaton, word: &str) -> usize {
+        let mut s = 0;
+        for b in word.bytes() {
+            s = (0..a.node_count())
+                .find(|&n| a.parent(n) == s && a.label(n) == b)
+                .expect("path exists");
+        }
+        s
+    }
+
+    #[test]
+    fn textbook_trie_has_exactly_ten_states() {
+        // root + h,he + s,sh,she + hi,his + her,hers — the classic figure.
+        assert_eq!(textbook().node_count(), 10);
+    }
+
+    #[test]
+    fn failure_links_match_the_textbook_exactly() {
+        let a = textbook();
+        // she → he (longest proper suffix that is a trie prefix)
+        assert_eq!(a.fail(state_for(&a, "she")), state_for(&a, "he"));
+        // sh → h ; her → root, since neither "er" nor "r" is a trie prefix
+        assert_eq!(a.fail(state_for(&a, "sh")), state_for(&a, "h"));
+        assert_eq!(a.fail(state_for(&a, "her")), 0);
+        // hi → root (no "i" child of root); his → s
+        assert_eq!(a.fail(state_for(&a, "hi")), 0);
+        assert_eq!(a.fail(state_for(&a, "his")), state_for(&a, "s"));
+        // depth-1 states always fail to root
+        assert_eq!(a.fail(state_for(&a, "h")), 0);
+        assert_eq!(a.fail(state_for(&a, "s")), 0);
+    }
+
+    #[test]
+    fn ushers_produces_the_three_textbook_matches_in_order() {
+        let a = textbook();
+        let mut c = Cursor::new(&a);
+        let mut found = Vec::new();
+        for (i, b) in "ushers".bytes().enumerate() {
+            for (pat, end) in c.step(b).matches {
+                found.push((pat, end));
+                assert_eq!(end, i + 1, "end must be the position after this byte");
+            }
+        }
+        // pattern indices: 0=he, 1=she, 2=his, 3=hers
+        assert_eq!(found, vec![(1, 4), (0, 4), (3, 6)]);
+    }
+
+    #[test]
+    fn suffix_outputs_are_merged_not_rediscovered() {
+        // "she" ends at position 4 and simultaneously ends "he" via the
+        // suffix link — both must be reported from the SAME landing state.
+        let a = textbook();
+        assert_eq!(a.outputs(state_for(&a, "she")), &[1, 0]);
+    }
+
+    #[test]
+    fn failure_hops_are_reported_for_the_visualizer() {
+        // After "ushe", stepping 'r': "sher" is not in the trie, so the
+        // cursor hops she→he before taking he→her. Exactly one hop,
+        // landing on "her".
+        let a = textbook();
+        let mut c = Cursor::new(&a);
+        for b in "ushe".bytes() {
+            c.step(b);
+        }
+        let ev = c.step(b'r');
+        assert_eq!(ev.hops, vec![state_for(&a, "he")]);
+        assert_eq!(ev.state, state_for(&a, "her"));
+    }
+
+    #[test]
+    fn build_rejects_bad_input_loudly() {
+        assert!(Automaton::build(&[]).is_err(), "no patterns");
+        assert!(Automaton::build(&["ok", ""]).is_err(), "empty pattern");
+        assert!(Automaton::build(&["abcdefghijk"]).is_err(), "over 10 chars");
+        let nine = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+        assert!(Automaton::build(&nine).is_err(), "over 8 patterns");
+        assert!(Automaton::build(&["He"]).is_ok(), "uppercase folds, not errors");
+    }
+
+    #[test]
+    fn overlapping_patterns_all_match() {
+        let a = Automaton::build(&["aa", "aaa"]).unwrap();
+        let mut c = Cursor::new(&a);
+        let mut found = Vec::new();
+        for b in "aaaa".bytes() {
+            found.extend(c.step(b).matches);
+        }
+        // aa ends at 2,3,4; aaa ends at 3,4.
+        assert_eq!(found, vec![(0, 2), (1, 3), (0, 3), (1, 4), (0, 4)]);
+    }
+}

--- a/crates/demos/aho-corasick-demo/src/automaton.rs
+++ b/crates/demos/aho-corasick-demo/src/automaton.rs
@@ -12,6 +12,7 @@ pub enum BuildError {
 const MAX_PATTERNS: usize = 8;
 const MAX_PATTERN_LEN: usize = 10;
 
+#[derive(Debug, PartialEq)]
 struct Node {
     label: u8,
     parent: usize,
@@ -21,6 +22,7 @@ struct Node {
     outputs: Vec<usize>,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Automaton {
     nodes: Vec<Node>,
 }
@@ -85,10 +87,9 @@ impl Automaton {
                 let label = nodes[c].label;
                 let mut f = nodes[u].fail;
                 let fail_of_c = loop {
+                    // f is always strictly shallower than u, so t can never be c itself.
                     if let Some(t) = nodes[f].children.iter().copied().find(|&t| nodes[t].label == label) {
-                        if t != c {
-                            break t;
-                        }
+                        break t;
                     }
                     if f == 0 {
                         break 0;
@@ -269,5 +270,43 @@ mod tests {
         }
         // aa ends at 2,3,4; aaa ends at 3,4.
         assert_eq!(found, vec![(0, 2), (1, 3), (0, 3), (1, 4), (0, 4)]);
+    }
+
+    #[test]
+    fn transitive_suffix_outputs_inherit_through_two_levels() {
+        // cba's outputs must inherit through ba, which itself inherits from a.
+        // A DFS/stack build order reads ba's outputs before ba has merged
+        // from a, yielding [2, 1] — this asserts the BFS invariant.
+        let a = Automaton::build(&["a", "ba", "cba"]).unwrap();
+        assert_eq!(a.outputs(state_for(&a, "cba")), &[2, 1, 0]);
+    }
+
+    #[test]
+    fn non_alphabetic_bytes_reset_and_still_count_positions() {
+        let a = Automaton::build(&["he"]).unwrap();
+        let mut c = Cursor::new(&a);
+        let mut found = Vec::new();
+        for b in "he he".bytes() {
+            let ev = c.step(b);
+            if b == b' ' {
+                assert_eq!(ev.state, 0, "space must reset to root");
+                assert!(ev.matches.is_empty() && ev.hops.is_empty());
+            }
+            found.extend(ev.matches);
+        }
+        // End positions count the space: 2 and 5 against the original text.
+        assert_eq!(found, vec![(0, 2), (0, 5)]);
+    }
+
+    #[test]
+    fn patterns_strip_non_alphabetic_rather_than_rejecting() {
+        let a = Automaton::build(&["h3-e"]).unwrap(); // folds to "he"
+        let mut c = Cursor::new(&a);
+        let mut found = Vec::new();
+        for b in "he".bytes() {
+            found.extend(c.step(b).matches);
+        }
+        assert_eq!(found, vec![(0, 2)]);
+        assert_eq!(Automaton::build(&["123"]), Err(BuildError::EmptyPattern));
     }
 }

--- a/crates/demos/aho-corasick-demo/src/layout.rs
+++ b/crates/demos/aho-corasick-demo/src/layout.rs
@@ -46,12 +46,11 @@ mod tests {
     use crate::automaton::Automaton;
 
     #[test]
-    #[allow(clippy::needless_range_loop)] // verbatim from brief; index doubles as `s` for depth(s)
     fn ys_equal_depths_exactly() {
         let a = Automaton::build(&["he", "she", "his", "hers"]).unwrap();
         let pos = layout(&a);
-        for s in 0..a.node_count() {
-            assert_eq!(pos[s].1, a.depth(s) as f32, "state {s}");
+        for (s, p) in pos.iter().enumerate() {
+            assert_eq!(p.1, a.depth(s) as f32, "state {s}");
         }
     }
 

--- a/crates/demos/aho-corasick-demo/src/layout.rs
+++ b/crates/demos/aho-corasick-demo/src/layout.rs
@@ -45,6 +45,21 @@ mod tests {
     use super::*;
     use crate::automaton::Automaton;
 
+    /// Walks the trie from the root along `word`, returning the state.
+    /// Duplicated from `automaton.rs`'s test-only helper: it lives inside
+    /// that module's `#[cfg(test)]` block and isn't importable across
+    /// modules, and widening the production API just for test plumbing
+    /// was already rejected in Task 1.
+    fn state_for(a: &Automaton, word: &str) -> usize {
+        let mut s = 0;
+        for b in word.bytes() {
+            s = (0..a.node_count())
+                .find(|&n| a.parent(n) == s && a.label(n) == b)
+                .expect("path exists");
+        }
+        s
+    }
+
     #[test]
     fn ys_equal_depths_exactly() {
         let a = Automaton::build(&["he", "she", "his", "hers"]).unwrap();
@@ -80,5 +95,22 @@ mod tests {
         let h = (0..a.node_count()).find(|&s| a.label(s) == b'h').unwrap();
         assert_eq!(pos[h].0, 0.5);
         assert_eq!(pos[0].0, 0.5);
+    }
+
+    /// The textbook automaton's leaves sit at unequal depths (hers at 4,
+    /// his and she at 3), so DFS leaf order (hers, his, she) differs from
+    /// any level-order numbering (which would visit his/she before hers).
+    /// Exact values pin the traversal order, not just the centring maths.
+    #[test]
+    fn asymmetric_depths_keep_dfs_leaf_order() {
+        let a = Automaton::build(&["he", "she", "his", "hers"]).unwrap();
+        let pos = layout(&a);
+        assert_eq!(pos[state_for(&a, "hers")].0, 0.0);
+        assert_eq!(pos[state_for(&a, "his")].0, 1.0);
+        assert_eq!(pos[state_for(&a, "she")].0, 2.0);
+        // h centres over e-subtree (0.0) and i-subtree (1.0); root over
+        // h (0.5) and s (2.0).
+        assert_eq!(pos[state_for(&a, "h")].0, 0.5);
+        assert_eq!(pos[0].0, 1.25);
     }
 }

--- a/crates/demos/aho-corasick-demo/src/layout.rs
+++ b/crates/demos/aho-corasick-demo/src/layout.rs
@@ -1,0 +1,85 @@
+//! Deterministic tidy-tree layout for the automaton's trie structure.
+//! Unit-free coordinates: y = depth, leaves at consecutive integer x in
+//! trie insertion order, internal nodes centred over their children.
+
+use crate::automaton::Automaton;
+
+/// Post-order visit: leaves consume the next free integer x slot
+/// left-to-right (children visited in insertion order); internal nodes
+/// take the mean x of their children. Returns the x assigned to `s`.
+fn visit(s: usize, a: &Automaton, children: &[Vec<usize>], next_x: &mut f32, pos: &mut [(f32, f32)]) -> f32 {
+    let y = a.depth(s) as f32;
+    let x = if children[s].is_empty() {
+        let x = *next_x;
+        *next_x += 1.0;
+        x
+    } else {
+        let sum: f32 = children[s].iter().map(|&c| visit(c, a, children, next_x, pos)).sum();
+        sum / children[s].len() as f32
+    };
+    pos[s] = (x, y);
+    x
+}
+
+/// Lays out every state of `a` in a unit-free coordinate space.
+/// `Automaton` does not expose a children list, but state ids are
+/// assigned in insertion order as the trie is built (`build` pushes a
+/// new node the moment it is discovered and immediately records it as
+/// its parent's child), so grouping states by `parent(s)` while walking
+/// `s` in ascending order reconstructs each parent's children in the
+/// same insertion order the trie built them in.
+pub fn layout(a: &Automaton) -> Vec<(f32, f32)> {
+    let n = a.node_count();
+    let mut children: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for s in 1..n {
+        children[a.parent(s)].push(s);
+    }
+    let mut pos = vec![(0.0f32, 0.0f32); n];
+    let mut next_x = 0.0f32;
+    visit(0, a, &children, &mut next_x, &mut pos);
+    pos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automaton::Automaton;
+
+    #[test]
+    #[allow(clippy::needless_range_loop)] // verbatim from brief; index doubles as `s` for depth(s)
+    fn ys_equal_depths_exactly() {
+        let a = Automaton::build(&["he", "she", "his", "hers"]).unwrap();
+        let pos = layout(&a);
+        for s in 0..a.node_count() {
+            assert_eq!(pos[s].1, a.depth(s) as f32, "state {s}");
+        }
+    }
+
+    #[test]
+    fn a_lone_chain_is_a_vertical_line_at_x_zero() {
+        let a = Automaton::build(&["abc"]).unwrap();
+        let pos = layout(&a);
+        assert_eq!(pos, vec![(0.0, 0.0), (0.0, 1.0), (0.0, 2.0), (0.0, 3.0)]);
+    }
+
+    #[test]
+    fn two_disjoint_chains_split_and_root_centres() {
+        // patterns "ab", "cd": leaves b at x=0, d at x=1 (insertion order),
+        // a over b, c over d, root centred at 0.5.
+        let a = Automaton::build(&["ab", "cd"]).unwrap();
+        let pos = layout(&a);
+        assert_eq!(pos[0].0, 0.5, "root centres over both subtrees");
+        let xs: Vec<f32> = (1..5).map(|s| pos[s].0).collect();
+        assert_eq!(xs, vec![0.0, 0.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn parents_centre_over_their_children() {
+        let a = Automaton::build(&["he", "hi"]).unwrap();
+        let pos = layout(&a);
+        // h has children e (x=0) and i (x=1) → h at 0.5; root over h at 0.5.
+        let h = (0..a.node_count()).find(|&s| a.label(s) == b'h').unwrap();
+        assert_eq!(pos[h].0, 0.5);
+        assert_eq!(pos[0].0, 0.5);
+    }
+}

--- a/crates/demos/aho-corasick-demo/src/lib.rs
+++ b/crates/demos/aho-corasick-demo/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod automaton;

--- a/crates/demos/aho-corasick-demo/src/lib.rs
+++ b/crates/demos/aho-corasick-demo/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod automaton;
+pub mod layout;

--- a/crates/demos/aho-corasick-demo/src/lib.rs
+++ b/crates/demos/aho-corasick-demo/src/lib.rs
@@ -1,2 +1,277 @@
-pub mod automaton;
-pub mod layout;
+mod automaton;
+mod layout;
+
+use automaton::Automaton;
+use wasm_bindgen::prelude::*;
+
+/// Text longer than this is silently truncated at construction; the demo
+/// page states the cap rather than surfacing a truncation error. Counted in
+/// bytes, not chars: `Automaton` only ever matches ASCII letters (see
+/// `automaton::fold`) and treats every other byte, including each byte of
+/// a multi-byte UTF-8 character, as a word-boundary reset, so a byte cap
+/// and a char cap coincide for the ASCII text this demo targets.
+const MAX_TEXT_LEN: usize = 200;
+
+/// Converts an automaton match — a `(pattern_index, end)` pair where `end`
+/// is the position (in the folded pattern's own units, which is bytes,
+/// counted from 1) immediately after the match — into a text byte range
+/// `[start, end)`. Pulled out as a pure function because an off-by-one here
+/// produces visually wrong highlights that no automaton test would catch:
+/// see the folded-length tests below.
+fn match_range(end: usize, folded_len: usize) -> (u32, u32) {
+    let start = end - folded_len;
+    (start as u32, end as u32)
+}
+
+/// The automaton, its static layout, and a streaming cursor over `text`,
+/// flattened for JS.
+///
+/// `automaton::Cursor<'a>` borrows the `Automaton` it walks, which cannot
+/// live alongside it inside a `#[wasm_bindgen]` struct (no lifetimes at the
+/// JS boundary). `Visualizer` instead holds `state`/`pos` as plain fields
+/// and drives the automaton itself via `Automaton::advance`, the same
+/// failure-hop stepping method `Cursor::step` delegates to — so the logic
+/// exists exactly once.
+#[wasm_bindgen]
+pub struct Visualizer {
+    automaton: Automaton,
+
+    xs: Vec<f32>,
+    ys: Vec<f32>,
+    labels: Vec<u8>,
+    parents: Vec<u32>,
+    fails: Vec<u32>,
+    terminal: Vec<u8>,
+
+    /// Folded length of each pattern, indexed by pattern index — the trie
+    /// strips non-alphabetic bytes and lowercases at build time, so this is
+    /// *not* the raw input pattern's length. Needed to convert `(pattern
+    /// index, end)` matches into text byte ranges.
+    pattern_lens: Vec<usize>,
+
+    text: Vec<u8>,
+    state: usize,
+    pos: usize,
+
+    hops: Vec<u32>,
+    match_starts: Vec<u32>,
+    match_ends: Vec<u32>,
+}
+
+#[wasm_bindgen]
+impl Visualizer {
+    /// Builds the automaton from comma-separated `patterns` and stores
+    /// `text` (truncated to `MAX_TEXT_LEN` bytes) for streaming. Build
+    /// errors — too many patterns, a pattern with no letters, a pattern
+    /// too long — surface as a JS exception carrying a readable message.
+    #[wasm_bindgen(constructor)]
+    pub fn new(patterns: &str, text: &str) -> Result<Visualizer, JsValue> {
+        let raw: Vec<&str> = patterns.split(',').collect();
+        let automaton = Automaton::build(&raw).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let pattern_lens: Vec<usize> = raw.iter().map(|p| automaton::fold(p).len()).collect();
+
+        let positions = layout::layout(&automaton);
+        let node_count = automaton.node_count();
+        let mut xs = Vec::with_capacity(node_count);
+        let mut ys = Vec::with_capacity(node_count);
+        let mut labels = Vec::with_capacity(node_count);
+        let mut parents = Vec::with_capacity(node_count);
+        let mut fails = Vec::with_capacity(node_count);
+        let mut terminal = Vec::with_capacity(node_count);
+        for (s, &(x, y)) in positions.iter().enumerate() {
+            xs.push(x);
+            ys.push(y);
+            labels.push(automaton.label(s));
+            parents.push(automaton.parent(s) as u32);
+            fails.push(automaton.fail(s) as u32);
+            terminal.push(u8::from(!automaton.outputs(s).is_empty()));
+        }
+
+        let mut text: Vec<u8> = text.bytes().collect();
+        text.truncate(MAX_TEXT_LEN);
+
+        Ok(Visualizer {
+            automaton,
+            xs,
+            ys,
+            labels,
+            parents,
+            fails,
+            terminal,
+            pattern_lens,
+            text,
+            state: 0,
+            pos: 0,
+            hops: Vec::new(),
+            match_starts: Vec::new(),
+            match_ends: Vec::new(),
+        })
+    }
+
+    /// Number of states in the automaton; every `*_ptr` array below is
+    /// exactly this long.
+    pub fn node_count(&self) -> usize {
+        self.automaton.node_count()
+    }
+
+    /// Pointer to the per-state x coordinates (unit-free tidy-tree layout).
+    ///
+    /// The caller MUST rebuild its typed-array view from this pointer on
+    /// every read and never cache it: wasm memory growth silently detaches
+    /// the backing `ArrayBuffer`, and a retained view then reads garbage or
+    /// throws.
+    pub fn xs_ptr(&self) -> *const f32 {
+        self.xs.as_ptr()
+    }
+
+    /// Pointer to the per-state y coordinates. Same rebuild-every-read
+    /// contract as [`Self::xs_ptr`].
+    pub fn ys_ptr(&self) -> *const f32 {
+        self.ys.as_ptr()
+    }
+
+    /// Pointer to the per-state trie-edge label byte (0 for the root). Same
+    /// rebuild-every-read contract as [`Self::xs_ptr`].
+    pub fn labels_ptr(&self) -> *const u8 {
+        self.labels.as_ptr()
+    }
+
+    /// Pointer to each state's parent index in the trie. Same
+    /// rebuild-every-read contract as [`Self::xs_ptr`].
+    pub fn parents_ptr(&self) -> *const u32 {
+        self.parents.as_ptr()
+    }
+
+    /// Pointer to each state's failure-link target. Same rebuild-every-read
+    /// contract as [`Self::xs_ptr`].
+    pub fn fails_ptr(&self) -> *const u32 {
+        self.fails.as_ptr()
+    }
+
+    /// Pointer to each state's terminal flag: 1 if the state has one or
+    /// more pattern outputs, 0 otherwise. Same rebuild-every-read contract
+    /// as [`Self::xs_ptr`].
+    pub fn terminal_ptr(&self) -> *const u8 {
+        self.terminal.as_ptr()
+    }
+
+    /// Length in bytes of the stored text (after the `MAX_TEXT_LEN` cap).
+    pub fn text_len(&self) -> usize {
+        self.text.len()
+    }
+
+    /// Rewinds the stream to the beginning without rebuilding the
+    /// automaton: state and position reset to 0, and the last step's
+    /// events are cleared.
+    pub fn reset(&mut self) {
+        self.state = 0;
+        self.pos = 0;
+        self.hops.clear();
+        self.match_starts.clear();
+        self.match_ends.clear();
+    }
+
+    /// Advances the cursor by one byte of the stored text. Returns `false`
+    /// once the text is exhausted (the cursor does not advance further);
+    /// `true` otherwise, with `current_state`, `hops_ptr`/`hops_len`, and
+    /// `match_*` refreshed for the step just taken.
+    pub fn step(&mut self) -> bool {
+        if self.pos >= self.text.len() {
+            return false;
+        }
+        let byte = self.text[self.pos];
+        self.pos += 1;
+        let (hops, state) = self.automaton.advance(self.state, byte);
+        self.state = state;
+
+        self.hops = hops.into_iter().map(|h| h as u32).collect();
+
+        self.match_starts.clear();
+        self.match_ends.clear();
+        for &pattern_index in self.automaton.outputs(state) {
+            let (start, end) = match_range(self.pos, self.pattern_lens[pattern_index]);
+            self.match_starts.push(start);
+            self.match_ends.push(end);
+        }
+        true
+    }
+
+    /// Bytes of the stored text consumed so far (0 after `reset`).
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    /// The automaton state the cursor currently sits on.
+    pub fn current_state(&self) -> usize {
+        self.state
+    }
+
+    /// Pointer to the failure hops taken during the most recent `step`
+    /// (empty before the first `step` or right after `reset`).
+    ///
+    /// This buffer is rewritten on every `step` call, so the rebuild-every-
+    /// read rule from [`Self::xs_ptr`] applies even more strictly here: a
+    /// view taken after one `step` is invalid by the next.
+    pub fn hops_ptr(&self) -> *const u32 {
+        self.hops.as_ptr()
+    }
+
+    /// Length of the buffer at `hops_ptr`.
+    pub fn hops_len(&self) -> usize {
+        self.hops.len()
+    }
+
+    /// Pointer to the inclusive start (in text bytes) of each match found
+    /// on the most recent `step`. Same per-step rebuild contract as
+    /// [`Self::hops_ptr`].
+    pub fn match_starts_ptr(&self) -> *const u32 {
+        self.match_starts.as_ptr()
+    }
+
+    /// Pointer to the exclusive end (in text bytes) of each match found on
+    /// the most recent `step`, parallel to `match_starts_ptr`. Same
+    /// per-step rebuild contract as [`Self::hops_ptr`].
+    pub fn match_ends_ptr(&self) -> *const u32 {
+        self.match_ends.as_ptr()
+    }
+
+    /// Length of the buffers at `match_starts_ptr` and `match_ends_ptr`.
+    pub fn match_len(&self) -> usize {
+        self.match_starts.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn match_range_uses_the_folded_length_not_the_raw_pattern_length() {
+        // "h3-e" folds to "he" (folded length 2, not the raw pattern's 4):
+        // a match ending at text byte 5 must start at 3, not 1.
+        assert_eq!(match_range(5, 2), (3, 5));
+    }
+
+    #[test]
+    fn visualizer_converts_matches_to_text_ranges_using_folded_lengths() {
+        // Textbook patterns, with "he" spelled as "h3-e" to pin the folded-
+        // length conversion against a pattern whose raw length (4) differs
+        // from its folded length (2).
+        let mut v = Visualizer::new("h3-e,she,his,hers", "ushers").unwrap();
+        let mut ranges: Vec<(u32, u32)> = Vec::new();
+        while v.step() {
+            let starts = unsafe { std::slice::from_raw_parts(v.match_starts_ptr(), v.match_len()) };
+            let ends = unsafe { std::slice::from_raw_parts(v.match_ends_ptr(), v.match_len()) };
+            ranges.extend(starts.iter().copied().zip(ends.iter().copied()));
+        }
+        // she: text[1..4]; he (folded from "h3-e"): text[2..4]; hers: text[2..6].
+        assert_eq!(ranges, vec![(1, 4), (2, 4), (2, 6)]);
+    }
+
+    // The constructor's error path (`JsValue::from_str`) calls into
+    // wasm-bindgen's JS-describe glue, which panics with "not implemented"
+    // outside a wasm32 target — so it can't be exercised from a native
+    // `cargo test`. `automaton::tests::build_error_messages_are_readable`
+    // covers the same `BuildError::to_string()` text this constructor
+    // relays verbatim via `.map_err(|e| JsValue::from_str(&e.to_string()))`.
+}

--- a/crates/site/src/build.rs
+++ b/crates/site/src/build.rs
@@ -184,7 +184,7 @@ pub fn build(root: &Path, out: &Path, strict: bool) -> Result<Vec<PathBuf>> {
     write(&out.join("robots.txt"), &robots_txt(&site), &mut written)?;
     write(
         &out.join("sitemap.xml"),
-        &sitemap_xml(&site, &[pages::demos::REACTION_DIFFUSION]),
+        &sitemap_xml(&site, &[pages::demos::REACTION_DIFFUSION, pages::demos::AHO_CORASICK]),
         &mut written,
     )?;
     write(
@@ -195,6 +195,11 @@ pub fn build(root: &Path, out: &Path, strict: bool) -> Result<Vec<PathBuf>> {
     write(
         &out.join("demos/reaction-diffusion/index.html"),
         &pages::demo_reaction_diffusion::render(&site).into_string(),
+        &mut written,
+    )?;
+    write(
+        &out.join("demos/aho-corasick/index.html"),
+        &pages::demo_aho_corasick::render(&site).into_string(),
         &mut written,
     )?;
     copy_tree(&root.join("static"), out, &mut written)?;
@@ -420,32 +425,99 @@ mod tests {
     }
 
     #[test]
-    fn wasm_loader_is_referenced_only_by_the_demo_page() {
+    fn wasm_loaders_are_referenced_only_by_their_own_demo_page() {
         let tmp = std::env::temp_dir().join("site-build-test-wasm-scope");
         let _ = std::fs::remove_dir_all(&tmp);
 
         build(Path::new("../.."), &tmp, false).expect("build succeeds");
 
+        // "loader.js" is a substring of "aho-loader.js" too, so this single
+        // check already catches either loader leaking onto a route page.
         for route in Route::ALL {
             let html = std::fs::read_to_string(tmp.join(route.output_path())).unwrap();
             assert!(
                 !html.contains("loader.js"),
-                "{:?} must not download the wasm demo loader: {html}",
+                "{:?} must not download any wasm demo loader: {html}",
                 route
             );
         }
         let not_found = std::fs::read_to_string(tmp.join("404.html")).unwrap();
         assert!(
             !not_found.contains("loader.js"),
-            "404 page must not download the wasm demo loader: {not_found}"
+            "404 page must not download any wasm demo loader: {not_found}"
         );
 
-        let demo_html = std::fs::read_to_string(tmp.join("demos/reaction-diffusion/index.html"))
-            .expect("demo page written");
+        // A plain `contains("loader.js")` cannot tell the two demo pages
+        // apart from each other — "aho-loader.js" contains "loader.js" as a
+        // substring — so isolation between the two demos needs the exact
+        // `src="..."` attribute value.
+        let rd_html = std::fs::read_to_string(tmp.join("demos/reaction-diffusion/index.html"))
+            .expect("reaction-diffusion demo page written");
         assert!(
-            demo_html.contains("loader.js"),
-            "demo page must load the wasm demo: {demo_html}"
+            rd_html.contains(r#"src="/demos/loader.js""#),
+            "reaction-diffusion demo must load its own loader: {rd_html}"
         );
+        assert!(
+            !rd_html.contains(r#"src="/demos/aho-loader.js""#),
+            "reaction-diffusion demo must not load the aho-corasick loader: {rd_html}"
+        );
+
+        let ac_html = std::fs::read_to_string(tmp.join("demos/aho-corasick/index.html"))
+            .expect("aho-corasick demo page written");
+        assert!(
+            ac_html.contains(r#"src="/demos/aho-loader.js""#),
+            "aho-corasick demo must load its own loader: {ac_html}"
+        );
+        assert!(
+            !ac_html.contains(r#"src="/demos/loader.js""#),
+            "aho-corasick demo must not load the reaction-diffusion loader: {ac_html}"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn build_writes_the_aho_corasick_demo_page_and_lists_it_in_the_sitemap() {
+        let tmp = std::env::temp_dir().join("site-build-test-ac-demo");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+        let site = Site::load(Path::new("../../content/site.toml")).unwrap();
+
+        assert!(
+            tmp.join("demos/aho-corasick/index.html").exists(),
+            "aho-corasick demo page not written"
+        );
+
+        let sitemap = std::fs::read_to_string(tmp.join("sitemap.xml")).expect("sitemap written");
+        assert!(
+            sitemap.contains(&format!("<loc>{}{}</loc>", site.url, pages::demos::AHO_CORASICK)),
+            "demo page missing from the sitemap: {sitemap}"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn aho_corasick_demo_claims_its_own_canonical_not_its_parent_routes() {
+        let tmp = std::env::temp_dir().join("site-build-test-ac-demo-canonical");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        build(Path::new("../.."), &tmp, false).expect("build succeeds");
+        let site = Site::load(Path::new("../../content/site.toml")).unwrap();
+
+        let html = std::fs::read_to_string(tmp.join("demos/aho-corasick/index.html"))
+            .expect("demo page written");
+        let expected_url = format!("{}{}", site.url, pages::demos::AHO_CORASICK);
+        assert!(
+            html.contains(&format!(r#"<link rel="canonical" href="{expected_url}">"#)),
+            "demo page canonical must be its own URL, not /demos/: {html}"
+        );
+        assert!(
+            html.contains(&format!(r#"<meta property="og:url" content="{expected_url}">"#)),
+            "demo page og:url must be its own URL, not /demos/: {html}"
+        );
+        assert!(!html.contains("noindex"), "demo page must not be noindexed: {html}");
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/site/src/pages/demo_aho_corasick.rs
+++ b/crates/site/src/pages/demo_aho_corasick.rs
@@ -1,0 +1,81 @@
+use crate::components::shell;
+use crate::content::Site;
+use crate::route::Route;
+use maud::{html, Markup};
+
+pub fn render(site: &Site) -> Markup {
+    let main = html! {
+        h1 { "Aho–Corasick" }
+        p .prose {
+            "The string-matching automaton behind the transaction-tagging rewrite on the projects page. "
+            "Patterns build a trie; failure links let a single pass over the text find every match. "
+            "Edit the patterns, then step or play the scan."
+        }
+
+        div .ac-controls {
+            input #ac-patterns .demo-input type="text" value="he, she, his, hers" aria-label="Patterns, comma-separated";
+            input #ac-text .demo-input type="text" value="ushers say she sells seashells" aria-label="Text to scan";
+            button #ac-rebuild .theme-toggle type="button" { "Rebuild" }
+            button #ac-play .theme-toggle type="button" { "Play" }
+            button #ac-step .theme-toggle type="button" { "Step" }
+            button #ac-reset .theme-toggle type="button" { "Reset" }
+            span #ac-status .mono { "loading" }
+        }
+
+        canvas #ac-canvas .ac-canvas aria-label="Aho-Corasick automaton graph" {}
+
+        div #ac-scan {}
+
+        p .mono { "solid = trie edge · dashed = failure link · filled = pattern end" }
+        p .mono { "lowercase a–z only, up to 8 patterns of 10 letters; text up to 200 characters" }
+
+        noscript {
+            p .prose { "This demo needs JavaScript and WebAssembly. The rest of the site works without either." }
+        }
+
+        script type="module" src="/demos/aho-loader.js" {}
+    };
+    shell::sub_page(site, Route::Demos, crate::pages::demos::AHO_CORASICK, "Aho–Corasick", main)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demo_page_has_a_canvas_and_loads_the_module_lazily() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(r#"id="ac-canvas""#), "canvas missing");
+        assert!(out.contains(r#"type="module""#), "module script missing");
+        assert!(out.contains("/demos/aho-loader.js"), "loader not referenced");
+        assert!(out.contains("noscript"), "no fallback for JS-disabled visitors");
+        assert!(
+            out.contains(r#"aria-label="Aho-Corasick automaton graph""#),
+            "canvas missing an accessible label"
+        );
+    }
+
+    #[test]
+    fn demo_page_has_pattern_and_text_controls_with_defaults() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(r#"id="ac-patterns""#), "pattern input missing");
+        assert!(out.contains(r#"value="he, she, his, hers""#), "default patterns missing");
+        assert!(out.contains(r#"id="ac-text""#), "text input missing");
+        assert!(
+            out.contains(r#"value="ushers say she sells seashells""#),
+            "default scan text missing"
+        );
+        assert!(out.contains(r#"id="ac-rebuild""#));
+        assert!(out.contains(r#"id="ac-play""#));
+        assert!(out.contains(r#"id="ac-step""#));
+        assert!(out.contains(r#"id="ac-reset""#));
+        assert!(out.contains(r#"id="ac-status""#));
+        assert!(out.contains(r#"id="ac-scan""#), "scan text container missing");
+    }
+
+    #[test]
+    fn demo_page_marks_demos_as_the_current_nav_item() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(r#"href="/demos/" aria-current="page""#));
+    }
+}

--- a/crates/site/src/pages/demo_aho_corasick.rs
+++ b/crates/site/src/pages/demo_aho_corasick.rs
@@ -19,7 +19,7 @@ pub fn render(site: &Site) -> Markup {
             button #ac-play .theme-toggle type="button" { "Play" }
             button #ac-step .theme-toggle type="button" { "Step" }
             button #ac-reset .theme-toggle type="button" { "Reset" }
-            span #ac-status .mono { "loading" }
+            span #ac-status .demo-status { "loading" }
         }
 
         canvas #ac-canvas .ac-canvas aria-label="Aho-Corasick automaton graph" {}
@@ -27,7 +27,7 @@ pub fn render(site: &Site) -> Markup {
         div #ac-scan {}
 
         p .mono { "solid = trie edge · dashed = failure link · filled = pattern end" }
-        p .mono { "lowercase a–z only, up to 8 patterns of 10 letters; text up to 200 characters" }
+        p .prose { "Lowercase a–z only, up to 8 patterns of 10 letters; text up to 200 characters." }
 
         noscript {
             p .prose { "This demo needs JavaScript and WebAssembly. The rest of the site works without either." }

--- a/crates/site/src/pages/demos.rs
+++ b/crates/site/src/pages/demos.rs
@@ -9,27 +9,49 @@ pub const REACTION_DIFFUSION: &str = "/demos/reaction-diffusion/";
 /// Path of the Aho-Corasick automaton visualizer demo page.
 pub const AHO_CORASICK: &str = "/demos/aho-corasick/";
 
+struct DemoEntry {
+    title: &'static str,
+    href: &'static str,
+    year: &'static str,
+    summary: &'static str,
+}
+
+/// Every demo listed on this page. The section header's count is derived
+/// from this slice's length (see `pages::index`/`pages::projects`, which
+/// derive their own section counts from `site.work.len()` the same way)
+/// rather than hand-typed, so adding or removing a demo can't silently
+/// leave a stale count behind.
+const DEMOS: [DemoEntry; 2] = [
+    DemoEntry {
+        title: "Reaction-Diffusion",
+        href: REACTION_DIFFUSION,
+        year: "2026",
+        summary: "A Gray-Scott simulation: two chemicals, one feeding on the other, painting patterns that look uncannily biological. Every pixel is computed in Rust, sixty times a second.",
+    },
+    DemoEntry {
+        title: "Aho–Corasick",
+        href: AHO_CORASICK,
+        year: "2026",
+        summary: "Build the automaton, watch failure links form, and stream text through it.",
+    },
+];
+
 pub fn render(site: &Site) -> Markup {
     let main = html! {
         h1 { "Demos" }
         p .prose { "Small things built in Rust, compiled to WebAssembly, running in your browser." }
         div .section-head {
             span .mono { "Demos" }
-            span .mono { "02" }
+            span .mono { (format!("{:02}", DEMOS.len())) }
         }
-        div .item {
-            div {
-                h3 { a href=(REACTION_DIFFUSION) { "Reaction-Diffusion" } }
-                p { "A Gray-Scott simulation: two chemicals, one feeding on the other, painting patterns that look uncannily biological. Every pixel is computed in Rust, sixty times a second." }
+        @for demo in DEMOS {
+            div .item {
+                div {
+                    h3 { a href=(demo.href) { (demo.title) } }
+                    p { (demo.summary) }
+                }
+                div .mono .year { (demo.year) }
             }
-            div .mono .year { "2026" }
-        }
-        div .item {
-            div {
-                h3 { a href=(AHO_CORASICK) { "Aho–Corasick" } }
-                p { "Build the automaton, watch failure links form, and stream text through it." }
-            }
-            div .mono .year { "2026" }
         }
     };
     shell::layout(site, Route::Demos, "Demos", main)
@@ -59,8 +81,13 @@ mod tests {
     }
 
     #[test]
-    fn demos_index_count_reflects_both_demos() {
+    fn demos_index_count_reflects_the_number_of_rendered_items() {
         let out = render(&crate::content::fixture_site()).into_string();
-        assert!(out.contains(r#"<span class="mono">02</span>"#), "count did not become 02: {out}");
+        let expected = format!(r#"<span class="mono">{:02}</span>"#, DEMOS.len());
+        assert!(out.contains(&expected), "count did not match DEMOS.len(): {out}");
+        // Guards the derivation itself, not just the string it produces:
+        // this would still pass a hardcoded "02" that drifted from a third
+        // demo being added without a count bump.
+        assert_eq!(DEMOS.len(), out.matches(r#"<div class="item">"#).count());
     }
 }

--- a/crates/site/src/pages/demos.rs
+++ b/crates/site/src/pages/demos.rs
@@ -6,18 +6,28 @@ use maud::{html, Markup};
 /// Path of the reaction-diffusion demo page. Task 5 renders it.
 pub const REACTION_DIFFUSION: &str = "/demos/reaction-diffusion/";
 
+/// Path of the Aho-Corasick automaton visualizer demo page.
+pub const AHO_CORASICK: &str = "/demos/aho-corasick/";
+
 pub fn render(site: &Site) -> Markup {
     let main = html! {
         h1 { "Demos" }
         p .prose { "Small things built in Rust, compiled to WebAssembly, running in your browser." }
         div .section-head {
             span .mono { "Demos" }
-            span .mono { "01" }
+            span .mono { "02" }
         }
         div .item {
             div {
                 h3 { a href=(REACTION_DIFFUSION) { "Reaction-Diffusion" } }
                 p { "A Gray-Scott simulation: two chemicals, one feeding on the other, painting patterns that look uncannily biological. Every pixel is computed in Rust, sixty times a second." }
+            }
+            div .mono .year { "2026" }
+        }
+        div .item {
+            div {
+                h3 { a href=(AHO_CORASICK) { "Aho–Corasick" } }
+                p { "Build the automaton, watch failure links form, and stream text through it." }
             }
             div .mono .year { "2026" }
         }
@@ -35,5 +45,22 @@ mod tests {
         assert!(out.contains(REACTION_DIFFUSION), "demo link missing");
         assert!(out.contains("Reaction-Diffusion"));
         assert!(out.contains(r#"href="/demos/" aria-current="page""#));
+    }
+
+    #[test]
+    fn demos_index_links_to_the_aho_corasick_demo() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(AHO_CORASICK), "demo link missing");
+        assert!(out.contains("Aho–Corasick"));
+        assert!(
+            out.contains("Build the automaton, watch failure links form, and stream text through it."),
+            "summary missing: {out}"
+        );
+    }
+
+    #[test]
+    fn demos_index_count_reflects_both_demos() {
+        let out = render(&crate::content::fixture_site()).into_string();
+        assert!(out.contains(r#"<span class="mono">02</span>"#), "count did not become 02: {out}");
     }
 }

--- a/crates/site/src/pages/mod.rs
+++ b/crates/site/src/pages/mod.rs
@@ -1,4 +1,5 @@
 pub mod about;
+pub mod demo_aho_corasick;
 pub mod demo_reaction_diffusion;
 pub mod demos;
 pub mod index;

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -272,7 +272,12 @@ h2 {{ font-size: 24px; letter-spacing: -0.02em; font-weight: 600; }}
 }}
 #ac-scan .consumed {{ color: var(--muted); }}
 #ac-scan .current {{ background: var(--accent); color: var(--surface); border-radius: 2px; }}
-#ac-scan .matched {{ background: var(--rule); border-bottom: 2px solid var(--accent); }}
+#ac-scan .matched {{ background: var(--rule); color: var(--ink); border-bottom: 2px solid var(--accent); }}
+.demo-status {{
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink);
+}}
 "#,
         light = tokens(LIGHT),
         dark = tokens(DARK),
@@ -403,6 +408,56 @@ mod tests {
         let css = stylesheet();
         for class in ["#ac-scan .consumed {", "#ac-scan .current {", "#ac-scan .matched {"] {
             assert!(css.contains(class), "stylesheet missing {class}: {css}");
+        }
+    }
+
+    #[test]
+    fn demo_status_class_used_in_markup_is_defined_here() {
+        // pages/demo_aho_corasick.rs writes `#ac-status` with `.demo-status`
+        // (10px uppercase `.mono` defeats "loud errors" for the status
+        // line that also carries build-error text) with nothing tying it
+        // to this stylesheet.
+        let css = stylesheet();
+        assert!(css.contains(".demo-status {"), "stylesheet missing .demo-status: {css}");
+        assert!(
+            !css.contains(".demo-status {\n  font-family: var(--font-mono);\n  font-size: 10px;"),
+            "status text must not be shrunk back to .mono's 10px uppercase treatment: {css}"
+        );
+    }
+
+    #[test]
+    fn matched_scan_text_meets_wcag_aa_against_its_own_background() {
+        // #ac-scan .matched sets an explicit `color: var(--ink)` on
+        // `background: var(--rule)` rather than inheriting `.consumed`'s
+        // `color: var(--muted)` — a matched character is normally also
+        // `consumed` (equal-specificity selectors, source order decides),
+        // and muted-on-rule is only 3.83:1, below AA. Pin both the text
+        // colour and the accent underline against that same background.
+        for (name, p) in [("light", LIGHT), ("dark", DARK)] {
+            let ink_ratio = contrast_ratio(p.ink, p.rule);
+            assert!(ink_ratio >= 4.5, "{name} ink-on-rule is {ink_ratio:.2}:1, below WCAG AA 4.5:1");
+            let accent_ratio = contrast_ratio(p.accent, p.rule);
+            assert!(
+                accent_ratio >= 4.5,
+                "{name} accent-on-rule is {accent_ratio:.2}:1, below WCAG AA 4.5:1"
+            );
+        }
+    }
+
+    #[test]
+    fn ac_scan_and_canvas_class_names_agree_with_the_loader_that_writes_them() {
+        // The stylesheet-tying tests above only prove these classes exist
+        // *somewhere* in this file — they don't prove the loader that
+        // actually writes/reads them still spells them the same way.
+        // Renaming a class in either place alone should break the build.
+        let css = stylesheet();
+        const LOADER_JS: &str = include_str!("../../../static/demos/aho-loader.js");
+        for class in ["consumed", "current", "matched", "ac-canvas"] {
+            assert!(css.contains(class), "stylesheet no longer mentions {class}: {css}");
+            assert!(
+                LOADER_JS.contains(class),
+                "static/demos/aho-loader.js no longer mentions {class}"
+            );
         }
     }
 

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -234,6 +234,45 @@ h2 {{ font-size: 24px; letter-spacing: -0.02em; font-weight: 600; }}
   align-items: center;
   max-width: 660px;
 }}
+
+.ac-canvas {{
+  width: 100%;
+  max-width: 720px;
+  aspect-ratio: 16 / 9;
+  display: block;
+  border: 1px solid var(--rule);
+  background: var(--surface);
+  margin: calc(var(--space) * 3) 0;
+}}
+.ac-controls {{
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space);
+  align-items: center;
+  max-width: 720px;
+  margin-bottom: calc(var(--space) * 2);
+}}
+.demo-input {{
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  padding: 5px 9px;
+}}
+#ac-scan {{
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.9;
+  max-width: 720px;
+  margin: calc(var(--space) * 2.5) 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}}
+#ac-scan .consumed {{ color: var(--muted); }}
+#ac-scan .current {{ background: var(--accent); color: var(--surface); border-radius: 2px; }}
+#ac-scan .matched {{ background: var(--rule); border-bottom: 2px solid var(--accent); }}
 "#,
         light = tokens(LIGHT),
         dark = tokens(DARK),
@@ -331,6 +370,40 @@ mod tests {
         assert!(css.contains("--paper: #0E0F11"), "dark tokens missing");
         assert!(css.contains("prefers-reduced-motion: reduce"));
         assert!(css.contains(":focus-visible"), "focus ring missing");
+    }
+
+    #[test]
+    fn ac_canvas_class_used_in_markup_is_defined_here() {
+        // pages/demo_aho_corasick.rs writes `.ac-canvas` with nothing tying
+        // it to this stylesheet.
+        let css = stylesheet();
+        assert!(css.contains(".ac-canvas {"), "stylesheet missing .ac-canvas: {css}");
+        assert!(
+            css.contains("aspect-ratio: 16 / 9;"),
+            "stylesheet missing the responsive aspect-ratio on .ac-canvas: {css}"
+        );
+    }
+
+    #[test]
+    fn demo_input_class_used_in_markup_is_defined_here() {
+        // pages/demo_aho_corasick.rs writes `.demo-input` with nothing
+        // tying it to this stylesheet.
+        let css = stylesheet();
+        assert!(css.contains(".demo-input {"), "stylesheet missing .demo-input: {css}");
+        assert!(
+            css.contains(".demo-input {\n  font-family: var(--font-mono);"),
+            "demo inputs should be set in the mono typeface: {css}"
+        );
+    }
+
+    #[test]
+    fn ac_scan_span_classes_used_in_markup_are_defined_here() {
+        // static/demos/aho-loader.js writes `.consumed`/`.current`/`.matched`
+        // spans inside `#ac-scan` with nothing tying them to this stylesheet.
+        let css = stylesheet();
+        for class in ["#ac-scan .consumed {", "#ac-scan .current {", "#ac-scan .matched {"] {
+            assert!(css.contains(class), "stylesheet missing {class}: {css}");
+        }
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-08-13-aho-corasick-demo.md
+++ b/docs/superpowers/plans/2026-08-13-aho-corasick-demo.md
@@ -1,0 +1,529 @@
+# Aho–Corasick Visualizer Demo — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A second WebAssembly demo at `/demos/aho-corasick/`: build an Aho–Corasick automaton from user-supplied patterns, draw its trie and failure links, and stream text through it with matches lighting up — the algorithm behind the owner's "hours to 90 seconds" Ampla work, visible.
+
+**Architecture:** A pure Rust crate module builds the automaton (trie, BFS failure links, merged outputs) and computes a tidy-tree layout — all natively tested. A thin `#[wasm_bindgen]` wrapper exposes structure and step events as flat arrays in linear memory. A hand-written JS module draws the graph on canvas and renders the scanned text as DOM spans, so match highlighting is real, selectable text.
+
+**Tech Stack:** Rust 1.92, `wasm-bindgen` 0.2.127, `maud` 0.27. No bundler, no npm, no other crates — building the automaton ourselves is the point; the crates.io `aho-corasick` crate must not appear.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **No threads** (GitHub Pages cannot serve COOP/COEP). Single-threaded only.
+- **No external hosts.** Everything self-hosted.
+- **WASM loads only on its own demo page.** The reaction-diffusion demo's isolation guard pattern extends to this one.
+- **Zero `#[allow(dead_code)]` anywhere in the tree.**
+- CI gates deploy on `cargo clippy --all-targets -- -D warnings` and `cargo test --all`.
+- Light is the default theme; dark is opt-in via `data-theme`. The demo must be legible in both, using only existing colour tokens.
+- `prefers-reduced-motion`: the automaton renders built and still; streaming never auto-plays for those visitors.
+- Inline theme scripts in `shell.rs`/`rail.rs` are untouched; their double-quoted JS keeps existing tests falsifying.
+- **If a closed-form expected value exists, assert it.** Seven tests on this project could not fail; every fix was an exact-value assertion. The `{he, she, his, hers}` / `"ushers"` textbook fixture has exact known matches and failure links — use them.
+- **Input caps** (legibility, not security — it all runs client-side): at most 8 patterns, each 1–10 chars, lowercase `a–z` only; scan text at most 200 chars. Uppercase folds to lowercase; other characters are stripped by the Rust side, and the page states the restriction.
+- Crate name is `aho-corasick-demo` (a local crate named `aho-corasick` would collide with the well-known crates.io name in every conversation about it). Artifacts live under `static/demos/aho-corasick/`.
+
+**The canonical fixture, used throughout:** patterns `["he", "she", "his", "hers"]`, text `"ushers"`. Matches (pattern, end-position-exclusive): `("she", 4)`, `("he", 4)`, `("hers", 6)`. The automaton has 10 states; the state for `"she"` fails to the state for `"he"` (suffix `he`), `"hers"`'s `r`-state fails to `"r"`… which doesn't exist, so to root — the exact link set is asserted in Task 1.
+
+---
+
+### Task 1: The automaton, natively tested
+
+**Files:**
+- Create: `crates/demos/aho-corasick-demo/Cargo.toml`, `crates/demos/aho-corasick-demo/src/automaton.rs`, `crates/demos/aho-corasick-demo/src/lib.rs`
+- Modify: `Cargo.toml` (workspace members)
+
+**Interfaces:**
+- Produces: `automaton::Automaton` with `build(patterns: &[&str]) -> Result<Automaton, BuildError>`, `node_count()`, `label(state) -> u8` (the byte on the incoming edge; 0 for root), `parent(state) -> usize`, `fail(state) -> usize`, `depth(state) -> usize`, `outputs(state) -> &[usize]` (pattern indices ending here, including via suffix links), and a streaming cursor: `Cursor::new(&Automaton)`, `cursor.step(byte) -> StepEvent` where `StepEvent { hops: Vec<usize>, state: usize, matches: Vec<(usize, usize)> }` (failure states traversed this step, the landing state, and `(pattern_index, end_pos)` matches). Tasks 2–3 consume all of these.
+
+- [ ] **Step 1: Workspace and manifest**
+
+Root `Cargo.toml` members become `["crates/site", "crates/demos/reaction-diffusion", "crates/demos/aho-corasick-demo"]`.
+
+`crates/demos/aho-corasick-demo/Cargo.toml`:
+
+```toml
+[package]
+name = "aho-corasick-demo"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.127"
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`src/automaton.rs`, tests module (implementation comes after):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn textbook() -> Automaton {
+        Automaton::build(&["he", "she", "his", "hers"]).unwrap()
+    }
+
+    /// Walks the trie from the root along `word`, returning the state.
+    fn state_for(a: &Automaton, word: &str) -> usize {
+        let mut s = 0;
+        for b in word.bytes() {
+            s = (0..a.node_count())
+                .find(|&n| a.parent(n) == s && a.label(n) == b)
+                .expect("path exists");
+        }
+        s
+    }
+
+    #[test]
+    fn textbook_trie_has_exactly_ten_states() {
+        // root + h,he + s,sh,she + hi,his + her,hers — the classic figure.
+        assert_eq!(textbook().node_count(), 10);
+    }
+
+    #[test]
+    fn failure_links_match_the_textbook_exactly() {
+        let a = textbook();
+        // she → he (longest proper suffix that is a trie prefix)
+        assert_eq!(a.fail(state_for(&a, "she")), state_for(&a, "he"));
+        // sh → h ; her → root, since neither "er" nor "r" is a trie prefix
+        assert_eq!(a.fail(state_for(&a, "sh")), state_for(&a, "h"));
+        assert_eq!(a.fail(state_for(&a, "her")), 0);
+        // hi → root (no "i" child of root); his → s
+        assert_eq!(a.fail(state_for(&a, "hi")), 0);
+        assert_eq!(a.fail(state_for(&a, "his")), state_for(&a, "s"));
+        // depth-1 states always fail to root
+        assert_eq!(a.fail(state_for(&a, "h")), 0);
+        assert_eq!(a.fail(state_for(&a, "s")), 0);
+    }
+
+    #[test]
+    fn ushers_produces_the_three_textbook_matches_in_order() {
+        let a = textbook();
+        let mut c = Cursor::new(&a);
+        let mut found = Vec::new();
+        for (i, b) in "ushers".bytes().enumerate() {
+            for (pat, end) in c.step(b).matches {
+                found.push((pat, end));
+                assert_eq!(end, i + 1, "end must be the position after this byte");
+            }
+        }
+        // pattern indices: 0=he, 1=she, 2=his, 3=hers
+        assert_eq!(found, vec![(1, 4), (0, 4), (3, 6)]);
+    }
+
+    #[test]
+    fn suffix_outputs_are_merged_not_rediscovered() {
+        // "she" ends at position 4 and simultaneously ends "he" via the
+        // suffix link — both must be reported from the SAME landing state.
+        let a = textbook();
+        assert_eq!(a.outputs(state_for(&a, "she")), &[1, 0]);
+    }
+
+    #[test]
+    fn failure_hops_are_reported_for_the_visualizer() {
+        // After "ushe", stepping 'r': "sher" is not in the trie, so the
+        // cursor hops she→he before taking he→her. Exactly one hop,
+        // landing on "her".
+        let a = textbook();
+        let mut c = Cursor::new(&a);
+        for b in "ushe".bytes() {
+            c.step(b);
+        }
+        let ev = c.step(b'r');
+        assert_eq!(ev.hops, vec![state_for(&a, "he")]);
+        assert_eq!(ev.state, state_for(&a, "her"));
+    }
+
+    #[test]
+    fn build_rejects_bad_input_loudly() {
+        assert!(Automaton::build(&[]).is_err(), "no patterns");
+        assert!(Automaton::build(&["ok", ""]).is_err(), "empty pattern");
+        assert!(Automaton::build(&["abcdefghijk"]).is_err(), "over 10 chars");
+        let nine = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+        assert!(Automaton::build(&nine).is_err(), "over 8 patterns");
+        assert!(Automaton::build(&["He"]).is_ok(), "uppercase folds, not errors");
+    }
+
+    #[test]
+    fn overlapping_patterns_all_match() {
+        let a = Automaton::build(&["aa", "aaa"]).unwrap();
+        let mut c = Cursor::new(&a);
+        let mut found = Vec::new();
+        for b in "aaaa".bytes() {
+            found.extend(c.step(b).matches);
+        }
+        // aa ends at 2,3,4; aaa ends at 3,4.
+        assert_eq!(found, vec![(0, 2), (1, 3), (0, 3), (1, 4), (0, 4)]);
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+`cargo test -p aho-corasick-demo` — FAIL, `Automaton` not found.
+
+- [ ] **Step 4: Implement**
+
+Above the tests:
+
+```rust
+//! Aho–Corasick automaton, built from scratch for the visualizer.
+//! Deliberately free of wasm so the algorithm is tested natively.
+
+#[derive(Debug, PartialEq)]
+pub enum BuildError {
+    NoPatterns,
+    TooManyPatterns,
+    EmptyPattern,
+    PatternTooLong,
+}
+
+const MAX_PATTERNS: usize = 8;
+const MAX_PATTERN_LEN: usize = 10;
+
+struct Node {
+    label: u8,
+    parent: usize,
+    depth: usize,
+    children: Vec<usize>, // indices into nodes; labels are unique per parent
+    fail: usize,
+    outputs: Vec<usize>,
+}
+
+pub struct Automaton {
+    nodes: Vec<Node>,
+}
+
+impl Automaton {
+    pub fn build(patterns: &[&str]) -> Result<Self, BuildError> {
+        if patterns.is_empty() {
+            return Err(BuildError::NoPatterns);
+        }
+        if patterns.len() > MAX_PATTERNS {
+            return Err(BuildError::TooManyPatterns);
+        }
+        let mut nodes = vec![Node {
+            label: 0,
+            parent: 0,
+            depth: 0,
+            children: Vec::new(),
+            fail: 0,
+            outputs: Vec::new(),
+        }];
+
+        for (pi, pat) in patterns.iter().enumerate() {
+            let folded: Vec<u8> = pat
+                .bytes()
+                .filter(|b| b.is_ascii_alphabetic())
+                .map(|b| b.to_ascii_lowercase())
+                .collect();
+            if folded.is_empty() {
+                return Err(BuildError::EmptyPattern);
+            }
+            if folded.len() > MAX_PATTERN_LEN {
+                return Err(BuildError::PatternTooLong);
+            }
+            let mut s = 0usize;
+            for &b in &folded {
+                s = match nodes[s].children.iter().copied().find(|&c| nodes[c].label == b) {
+                    Some(c) => c,
+                    None => {
+                        let id = nodes.len();
+                        let depth = nodes[s].depth + 1;
+                        nodes.push(Node {
+                            label: b,
+                            parent: s,
+                            depth,
+                            children: Vec::new(),
+                            fail: 0,
+                            outputs: Vec::new(),
+                        });
+                        nodes[s].children.push(id);
+                        id
+                    }
+                };
+            }
+            nodes[s].outputs.push(pi);
+        }
+
+        // BFS failure links; merge suffix outputs as we go.
+        let mut queue: std::collections::VecDeque<usize> = nodes[0].children.clone().into();
+        while let Some(u) = queue.pop_front() {
+            for c in nodes[u].children.clone() {
+                queue.push_back(c);
+                let label = nodes[c].label;
+                let mut f = nodes[u].fail;
+                let fail_of_c = loop {
+                    if let Some(t) = nodes[f].children.iter().copied().find(|&t| nodes[t].label == label) {
+                        if t != c {
+                            break t;
+                        }
+                    }
+                    if f == 0 {
+                        break 0;
+                    }
+                    f = nodes[f].fail;
+                };
+                nodes[c].fail = fail_of_c;
+                let inherited = nodes[fail_of_c].outputs.clone();
+                nodes[c].outputs.extend(inherited);
+            }
+        }
+        Ok(Automaton { nodes })
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+    pub fn label(&self, s: usize) -> u8 {
+        self.nodes[s].label
+    }
+    pub fn parent(&self, s: usize) -> usize {
+        self.nodes[s].parent
+    }
+    pub fn fail(&self, s: usize) -> usize {
+        self.nodes[s].fail
+    }
+    pub fn depth(&self, s: usize) -> usize {
+        self.nodes[s].depth
+    }
+    pub fn outputs(&self, s: usize) -> &[usize] {
+        &self.nodes[s].outputs
+    }
+
+    fn child(&self, s: usize, b: u8) -> Option<usize> {
+        self.nodes[s].children.iter().copied().find(|&c| self.nodes[c].label == b)
+    }
+}
+
+pub struct StepEvent {
+    pub hops: Vec<usize>,
+    pub state: usize,
+    pub matches: Vec<(usize, usize)>,
+}
+
+pub struct Cursor<'a> {
+    automaton: &'a Automaton,
+    state: usize,
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    pub fn new(automaton: &'a Automaton) -> Self {
+        Cursor { automaton, state: 0, pos: 0 }
+    }
+
+    /// Advance one byte. Non-alphabetic bytes reset to root (word boundary).
+    pub fn step(&mut self, byte: u8) -> StepEvent {
+        self.pos += 1;
+        if !byte.is_ascii_alphabetic() {
+            self.state = 0;
+            return StepEvent { hops: Vec::new(), state: 0, matches: Vec::new() };
+        }
+        let b = byte.to_ascii_lowercase();
+        let mut hops = Vec::new();
+        while self.automaton.child(self.state, b).is_none() && self.state != 0 {
+            self.state = self.automaton.fail(self.state);
+            hops.push(self.state);
+        }
+        if let Some(next) = self.automaton.child(self.state, b) {
+            self.state = next;
+        }
+        let matches = self
+            .automaton
+            .outputs(self.state)
+            .iter()
+            .map(|&pi| (pi, self.pos))
+            .collect();
+        StepEvent { hops, state: self.state, matches }
+    }
+}
+```
+
+`src/lib.rs`: `pub mod automaton;` (the Task 3 wrapper will consume it and visibility gets revisited then, as in bucket 4).
+
+- [ ] **Step 5: Verify and commit**
+
+`cargo test -p aho-corasick-demo` — 7 tests PASS. `cargo clippy --all-targets -- -D warnings` clean. If clippy flags dead code on the unconsumed API, follow the bucket-4 precedent (`pub mod` until the wasm wrapper consumes it) — never `#[allow(dead_code)]`.
+
+```bash
+git add Cargo.toml Cargo.lock crates/demos/aho-corasick-demo
+git commit -m "feat: add Aho-Corasick automaton with textbook closed-form tests"
+```
+
+---
+
+### Task 2: Tidy-tree layout
+
+**Files:**
+- Create: `crates/demos/aho-corasick-demo/src/layout.rs`
+- Modify: `src/lib.rs`
+
+**Interfaces:**
+- Consumes: `Automaton` (parent/depth/child structure).
+- Produces: `layout::layout(a: &Automaton) -> Vec<(f32, f32)>` — one `(x, y)` per state in a unit-free coordinate space: `y = depth as f32`, leaves at consecutive integer `x` in trie insertion order, internal nodes centred over their children, root centred over everything. Task 3 ships these to JS, which scales them to the canvas.
+
+- [ ] **Step 1: Failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automaton::Automaton;
+
+    #[test]
+    fn ys_equal_depths_exactly() {
+        let a = Automaton::build(&["he", "she", "his", "hers"]).unwrap();
+        let pos = layout(&a);
+        for s in 0..a.node_count() {
+            assert_eq!(pos[s].1, a.depth(s) as f32, "state {s}");
+        }
+    }
+
+    #[test]
+    fn a_lone_chain_is_a_vertical_line_at_x_zero() {
+        let a = Automaton::build(&["abc"]).unwrap();
+        let pos = layout(&a);
+        assert_eq!(pos, vec![(0.0, 0.0), (0.0, 1.0), (0.0, 2.0), (0.0, 3.0)]);
+    }
+
+    #[test]
+    fn two_disjoint_chains_split_and_root_centres() {
+        // patterns "ab", "cd": leaves b at x=0, d at x=1 (insertion order),
+        // a over b, c over d, root centred at 0.5.
+        let a = Automaton::build(&["ab", "cd"]).unwrap();
+        let pos = layout(&a);
+        assert_eq!(pos[0].0, 0.5, "root centres over both subtrees");
+        let xs: Vec<f32> = (1..5).map(|s| pos[s].0).collect();
+        assert_eq!(xs, vec![0.0, 0.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn parents_centre_over_their_children() {
+        let a = Automaton::build(&["he", "hi"]).unwrap();
+        let pos = layout(&a);
+        // h has children e (x=0) and i (x=1) → h at 0.5; root over h at 0.5.
+        let h = (0..a.node_count()).find(|&s| a.label(s) == b'h').unwrap();
+        assert_eq!(pos[h].0, 0.5);
+        assert_eq!(pos[0].0, 0.5);
+    }
+}
+```
+
+- [ ] **Step 2: Verify failure, implement**
+
+Post-order walk: leaves take the next free integer slot left-to-right (children in stored insertion order); internal nodes take the mean of their children's x. Root included. ~30 lines; no recursion limits at depth ≤ 11.
+
+- [ ] **Step 3: Verify and commit**
+
+`cargo test -p aho-corasick-demo` — 11 PASS; clippy clean.
+
+```bash
+git add crates/demos/aho-corasick-demo/src
+git commit -m "feat: add deterministic tidy-tree layout for the automaton"
+```
+
+---
+
+### Task 3: WASM boundary and build script
+
+**Files:**
+- Modify: `crates/demos/aho-corasick-demo/src/lib.rs`, `scripts/build-wasm.sh`, `.gitignore`
+
+**Interfaces:**
+- Produces for JS (all names verbatim — the loader calls exactly these): `new Visualizer(patterns: &str, text: &str)` (patterns comma-separated; constructor errors become a JS exception with a readable message), `node_count()`, `xs_ptr()`, `ys_ptr()` (f32 arrays, one per state), `labels_ptr()` (u8 per state), `parents_ptr()`, `fails_ptr()` (u32 per state), `terminal_ptr()` (u8 per state, 1 if the state has outputs), `text_len()`, `reset()`, `step() -> bool` (advance one char; false when exhausted), then post-step accessors `current_state()`, `hops_ptr()`/`hops_len()`, `match_starts_ptr()`/`match_ends_ptr()`/`match_len()` (u32 arrays; this step's matches as text ranges, start inclusive, end exclusive — the wrapper converts `(pattern_idx, end)` to ranges using pattern lengths), and `pos()` (chars consumed).
+- Every `_ptr` carries the established contract comment: rebuild the typed-array view every read; never cache it across wasm calls.
+
+- [ ] **Step 1:** Implement the wrapper: build `Automaton` + `layout` in the constructor, flatten into owned `Vec`s, hold a rebuilt-per-`reset` cursor by index (store `state: usize` and re-drive the automaton — the borrow-holding `Cursor<'a>` cannot live in a wasm struct; give `automaton.rs` a small owned-cursor variant or inline the stepping loop in the wrapper, whichever is cleaner, without duplicating the failure-hop logic — expose it from `automaton.rs` as a free function if needed).
+
+- [ ] **Step 2:** Extend `scripts/build-wasm.sh` to build **both** crates — factor the three-line build-and-bindgen sequence into a shell function called once per crate (`reaction_diffusion` → `static/demos/reaction-diffusion`, `aho_corasick_demo` → `static/demos/aho-corasick`). Append `/static/demos/aho-corasick/` to `.gitignore`.
+
+- [ ] **Step 3:** Build; verify both artifact sets exist; record the new `.wasm` size (raw and gzipped) in the report. `cargo test --all` and clippy clean.
+
+```bash
+git add crates/demos/aho-corasick-demo/src/lib.rs scripts/build-wasm.sh .gitignore
+git commit -m "feat: expose the automaton visualizer to WebAssembly"
+```
+
+---
+
+### Task 4: Demo page, loader, and demos index entry
+
+**Files:**
+- Create: `crates/site/src/pages/demo_aho_corasick.rs`, `static/demos/aho-loader.js`
+- Modify: `crates/site/src/pages/demos.rs`, `crates/site/src/build.rs`, `crates/site/src/theme.rs`, `crates/site/src/pages/mod.rs`
+
+**Interfaces:**
+- Produces: `pages::demos::AHO_CORASICK: &str = "/demos/aho-corasick/"`, `pages::demo_aho_corasick::render(site) -> Markup`, written by `build()` to `demos/aho-corasick/index.html` (not a `Route`; not in the nav; **in the sitemap** via the extra-paths argument, exactly like the reaction-diffusion page).
+
+Page structure (follow `demo_reaction_diffusion.rs`'s shape — `sub_page` for the canonical, `noscript`, module script):
+
+- `h1 "Aho–Corasick"`, one `.prose` paragraph: *"The string-matching automaton behind the transaction-tagging rewrite on the projects page. Patterns build a trie; failure links let a single pass over the text find every match. Edit the patterns, then step or play the scan."* (owner-voice: system facts, one pointer, no self-praise)
+- Controls row: pattern input (`input .demo-input #ac-patterns`, default `he, she, his, hers`), text input (`#ac-text`, default `ushers say she sells seashells`), Rebuild / Play–Pause / Step / Reset buttons (`.theme-toggle` styling), `#ac-status .mono`
+- `canvas #ac-canvas .ac-canvas aria-label="Aho-Corasick automaton graph"` — the graph
+- `#ac-scan` — the scanned text as DOM spans (real text; the loader marks consumed chars, the current char, and matched ranges with classes)
+- Legend line in `.mono`: solid = trie edge, dashed = failure link, filled = pattern end
+
+Loader (`aho-loader.js`, ES module, only this page references it):
+
+- Guard all element lookups as a group (bucket-4 lesson); `.catch` on `main()` setting a visible "failed to load" status
+- Rebuild constructs a new `Visualizer` inside try/catch; a build error shows the message in `#ac-status`, keeping the previous automaton live
+- Canvas draw: scale unit coords to the canvas with padding; trie edges as lines; failure links as dashed quadratic arcs (skip arcs whose target is the root — every shallow state fails to root and drawing them is pure clutter; state this in a comment); nodes as circles, letter labels, terminal states filled with `--accent`, current state ring-highlighted, hop states flashed
+- Play loop: generation-token pattern **copied from `loader.js`** (the double-rAF lesson); speed fixed at ~3 steps/second — a speed slider is YAGNI until someone asks
+- Colours read from `getComputedStyle` custom properties at draw time, and the existing `data-theme` MutationObserver pattern redraws a paused canvas on theme change (bucket-4 lesson I2)
+- Reduced-motion: build and draw the automaton, never auto-play; status "paused — reduced motion"
+- Text spans: `.consumed`, `.current`, `.matched` classes; matched ranges accumulate
+
+CSS additions (braces doubled): `.ac-canvas` (responsive, `aspect-ratio: 16 / 9`, hairline border, white background in both themes like `.resume-page`? No — use `var(--surface)` so it participates in the theme), `.demo-input` (mono, surface background, rule border, focus ring inherited), `.ac-scan` classes (`.consumed` muted, `.current` inverse ring, `.matched` accent underline/background at AA contrast — use the existing tokens only), plus stylesheet-tying test entries.
+
+Demos index (`pages/demos.rs`): second `.item` — title "Aho–Corasick", year "2026", link via `AHO_CORASICK`, summary *"Build the automaton, watch failure links form, and stream text through it."*, count `02`.
+
+Build tests: page exists at `dist/demos/aho-corasick/index.html`; its canonical and `og:url` are its own URL; sitemap contains it; **loader isolation guard extended** — loop `Route::ALL` + `404.html` asserting neither `loader.js` nor `aho-loader.js` appears, demo pages each reference exactly their own loader.
+
+Manual verification: build wasm, strict build, serve, and in a browser: automaton renders; Rebuild with changed patterns works; bad input (empty, 9 patterns, long pattern) shows an error without killing the page; Step walks "ushers" showing the she→he hop; matches highlight `she`/`he`/`hers` overlapping correctly; theme toggle recolours a paused canvas; reduced-motion stays still. Report observations.
+
+```bash
+git add crates/site/src static/demos/aho-loader.js
+git commit -m "feat: add the Aho-Corasick visualizer demo page and loader"
+```
+
+---
+
+### Task 5: CI
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml`
+
+`Build WebAssembly` already runs `scripts/build-wasm.sh`, which now builds both crates — no new build step. Extend `Verify wasm shipped`:
+
+```yaml
+        test -f dist/demos/aho-corasick/aho_corasick_demo_bg.wasm
+        test -f dist/demos/aho-corasick/aho_corasick_demo.js
+        grep -q 'aho-loader.js' dist/demos/aho-corasick/index.html
+```
+
+(the bucket-4 lesson: artifact assertions live in the workflow step where artifacts exist, and the grep proves the page references them). Validate YAML parses and step order is unchanged; `deploy` job untouched.
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci: verify the Aho-Corasick demo ships"
+```
+
+---
+
+## Definition of Done
+
+- `/demos/aho-corasick/` live: automaton drawn with failure links, editable patterns with loud-but-survivable input errors, step/play scan with overlapping matches highlighted in real DOM text.
+- The `"ushers"` walk visibly shows a failure hop (she→he on the `r`).
+- `/demos/` lists two demos; the new page is self-canonical and in the sitemap; nav unchanged.
+- No page outside `/demos/aho-corasick/` references its loader or wasm; reaction-diffusion's isolation is preserved verbatim.
+- Reduced-motion visitors get a still, built automaton. Theme changes recolour a paused canvas.
+- CI builds both wasm crates and fails if either demo's artifacts or page references are missing.
+- `cargo test --all` and `cargo clippy --all-targets -- -D warnings` green; zero `#[allow(dead_code)]`; every new physics/layout/stepping assertion is a closed-form exact value.

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
-# Builds the reaction-diffusion demo to WebAssembly and emits the JS bindings.
+# Builds each wasm demo crate and emits its JS bindings.
 # Run before `cargo run -p site` so the generator can copy the artifacts.
 set -euo pipefail
 
-OUT=static/demos/reaction-diffusion
+# Builds $1 (a crate name) to wasm32-unknown-unknown and runs wasm-bindgen
+# over the result, writing artifacts to $2. $3 is the crate name with
+# hyphens replaced by underscores, matching cargo's build output filename.
+build_wasm_crate() {
+  local crate=$1
+  local out=$2
+  local module=$3
 
-cargo build -p reaction-diffusion --target wasm32-unknown-unknown --release
+  cargo build -p "$crate" --target wasm32-unknown-unknown --release
 
-mkdir -p "$OUT"
-wasm-bindgen \
-  --target web \
-  --no-typescript \
-  --out-dir "$OUT" \
-  target/wasm32-unknown-unknown/release/reaction_diffusion.wasm
+  mkdir -p "$out"
+  wasm-bindgen \
+    --target web \
+    --no-typescript \
+    --out-dir "$out" \
+    "target/wasm32-unknown-unknown/release/${module}.wasm"
 
-echo "wasm artifacts in $OUT:"
-ls -la "$OUT"
+  echo "wasm artifacts in $out:"
+  ls -la "$out"
+}
+
+build_wasm_crate reaction-diffusion static/demos/reaction-diffusion reaction_diffusion
+build_wasm_crate aho-corasick-demo static/demos/aho-corasick aho_corasick_demo

--- a/static/demos/aho-loader.js
+++ b/static/demos/aho-loader.js
@@ -1,0 +1,343 @@
+// Lazy loader for the Aho-Corasick visualizer demo. Only this page imports
+// it, so no other page on the site downloads this WebAssembly module.
+import init, { Visualizer } from "./aho-corasick/aho_corasick_demo.js";
+
+const MAX_TEXT_LEN = 200; // must match Visualizer's own byte cap
+const STEP_MS = 1000 / 3; // ~3 steps/second
+
+// The wasm's 200 cap is a *byte* cap that only equals a char cap for ASCII
+// text (see the crate's MAX_TEXT_LEN doc comment). Stripping non-ASCII here
+// — mirroring what the Rust side folds away from patterns anyway — keeps
+// byte offsets, JS string indices, and the DOM spans built from this same
+// string all in agreement, so the match ranges the wasm reports (byte
+// offsets into the *stored* text) can index straight into those spans.
+function stripNonAscii(s) {
+  return s.replace(/[^\x00-\x7F]/g, "");
+}
+
+function sanitizeText(s) {
+  return stripNonAscii(s).slice(0, MAX_TEXT_LEN);
+}
+
+async function main() {
+  const canvas = document.getElementById("ac-canvas");
+  const status = document.getElementById("ac-status");
+  const patternsInput = document.getElementById("ac-patterns");
+  const textInput = document.getElementById("ac-text");
+  const scan = document.getElementById("ac-scan");
+  const rebuildBtn = document.getElementById("ac-rebuild");
+  const playBtn = document.getElementById("ac-play");
+  const stepBtn = document.getElementById("ac-step");
+  const resetBtn = document.getElementById("ac-reset");
+  if (
+    !canvas || !status || !patternsInput || !textInput || !scan ||
+    !rebuildBtn || !playBtn || !stepBtn || !resetBtn
+  ) return;
+
+  const wasm = await init();
+  const ctx = canvas.getContext("2d");
+
+  let viz = null;
+  let text = "";
+  let running = false;
+  let generation = 0;
+  let lastStepAt = 0;
+  let matched = []; // accumulated [start, end) text ranges; cleared on reset/rebuild
+  let hopStates = new Set(); // states landed on by the most recent step's failure hops
+
+  const cssVar = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+
+  function buildScan() {
+    scan.textContent = "";
+    for (const ch of text) {
+      const span = document.createElement("span");
+      span.textContent = ch;
+      scan.appendChild(span);
+    }
+  }
+
+  function refreshScanClasses() {
+    const spans = scan.children;
+    const pos = viz ? viz.pos() : 0;
+    for (let i = 0; i < spans.length; i++) {
+      spans[i].className = i < pos ? "consumed" : "";
+    }
+    if (viz && pos < spans.length) {
+      spans[pos].className = "current";
+    }
+    for (const [start, end] of matched) {
+      for (let i = start; i < end && i < spans.length; i++) {
+        spans[i].classList.add("matched");
+      }
+    }
+  }
+
+  // Rebuilds every typed-array view from the live pointer on every read:
+  // wasm memory growth silently detaches the backing ArrayBuffer, and a
+  // retained view then reads garbage or throws (see Visualizer's *_ptr doc
+  // comments in the wasm crate).
+  function readNodeArrays() {
+    const n = viz.node_count();
+    return {
+      xs: new Float32Array(wasm.memory.buffer, viz.xs_ptr(), n),
+      ys: new Float32Array(wasm.memory.buffer, viz.ys_ptr(), n),
+      labels: new Uint8Array(wasm.memory.buffer, viz.labels_ptr(), n),
+      parents: new Uint32Array(wasm.memory.buffer, viz.parents_ptr(), n),
+      fails: new Uint32Array(wasm.memory.buffer, viz.fails_ptr(), n),
+      terminal: new Uint8Array(wasm.memory.buffer, viz.terminal_ptr(), n),
+    };
+  }
+
+  function readHops() {
+    const len = viz.hops_len();
+    return len === 0 ? [] : Array.from(new Uint32Array(wasm.memory.buffer, viz.hops_ptr(), len));
+  }
+
+  function readMatches() {
+    const len = viz.match_len();
+    if (len === 0) return [];
+    const starts = new Uint32Array(wasm.memory.buffer, viz.match_starts_ptr(), len);
+    const ends = new Uint32Array(wasm.memory.buffer, viz.match_ends_ptr(), len);
+    const out = [];
+    for (let i = 0; i < len; i++) out.push([starts[i], ends[i]]);
+    return out;
+  }
+
+  function draw() {
+    if (!viz) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const cw = Math.max(1, Math.round(rect.width * dpr));
+    const ch = Math.max(1, Math.round(rect.height * dpr));
+    if (canvas.width !== cw || canvas.height !== ch) {
+      canvas.width = cw;
+      canvas.height = ch;
+    }
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const w = rect.width, h = rect.height;
+    ctx.clearRect(0, 0, w, h);
+
+    const { xs, ys, labels, parents, fails, terminal } = readNodeArrays();
+    const n = xs.length;
+
+    let minX = Infinity, maxX = -Infinity, maxY = 0;
+    for (let i = 0; i < n; i++) {
+      if (xs[i] < minX) minX = xs[i];
+      if (xs[i] > maxX) maxX = xs[i];
+      if (ys[i] > maxY) maxY = ys[i];
+    }
+    const pad = 26;
+    const spanX = Math.max(1e-6, maxX - minX);
+    const spanY = Math.max(1e-6, maxY);
+    const px = (x) => (spanX === 0 ? w / 2 : pad + ((x - minX) / spanX) * (w - 2 * pad));
+    const py = (y) => pad + (y / spanY) * (h - 2 * pad);
+
+    const rule = cssVar("--rule");
+    const ink = cssVar("--ink");
+    const muted = cssVar("--muted");
+    const accent = cssVar("--accent");
+    const surface = cssVar("--surface");
+
+    const current = viz.current_state();
+    const radius = Math.max(8, Math.min(14, w / (n + 4)));
+
+    // Trie edges: solid line, parent -> child.
+    ctx.strokeStyle = rule;
+    ctx.lineWidth = 1.5;
+    ctx.setLineDash([]);
+    for (let i = 1; i < n; i++) {
+      const p = parents[i];
+      ctx.beginPath();
+      ctx.moveTo(px(xs[p]), py(ys[p]));
+      ctx.lineTo(px(xs[i]), py(ys[i]));
+      ctx.stroke();
+    }
+
+    // Failure links: dashed quadratic arcs. Arcs whose target is the root
+    // are skipped — nearly every shallow state fails to root, so drawing
+    // all of those is pure clutter that would bury the failure links that
+    // actually matter (the deeper, more interesting ones).
+    ctx.strokeStyle = muted;
+    ctx.setLineDash([4, 3]);
+    for (let i = 1; i < n; i++) {
+      const f = fails[i];
+      if (f === 0) continue;
+      const x0 = px(xs[i]), y0 = py(ys[i]);
+      const x1 = px(xs[f]), y1 = py(ys[f]);
+      const mx = (x0 + x1) / 2;
+      const my = (y0 + y1) / 2 - 20;
+      ctx.beginPath();
+      ctx.moveTo(x0, y0);
+      ctx.quadraticCurveTo(mx, my, x1, y1);
+      ctx.stroke();
+    }
+    ctx.setLineDash([]);
+
+    // Nodes: circles with letter labels. Terminal states are filled with
+    // the accent; the current state gets an extra ring; states the last
+    // step's failure hops passed through are flashed with an accent
+    // outline.
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.font = `${Math.max(9, radius)}px var(--font-mono), ui-monospace, monospace`;
+    for (let i = 0; i < n; i++) {
+      const x = px(xs[i]), y = py(ys[i]);
+      const isTerminal = terminal[i] === 1;
+      const isCurrent = i === current;
+      const isHop = hopStates.has(i);
+
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.fillStyle = isTerminal ? accent : surface;
+      ctx.fill();
+      ctx.lineWidth = 1.5;
+      ctx.strokeStyle = ink;
+      ctx.stroke();
+
+      // The hop flash is drawn as an outer ring rather than recolouring the
+      // node's own stroke: a terminal state is already filled with
+      // `accent`, so an accent-coloured inner stroke would sit flush
+      // against a same-coloured fill and be invisible right when the flash
+      // matters most (a hop landing on a pattern-ending state). An outer
+      // ring drawn against the page background stays visible regardless of
+      // the node's own fill colour; dashed, so it reads as distinct from
+      // the current-state ring below even on the rare node that is both.
+      if (isHop) {
+        ctx.beginPath();
+        ctx.setLineDash([2, 2]);
+        ctx.arc(x, y, radius + 4, 0, Math.PI * 2);
+        ctx.strokeStyle = accent;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+
+      if (isCurrent) {
+        ctx.beginPath();
+        ctx.arc(x, y, radius + (isHop ? 8 : 4), 0, Math.PI * 2);
+        ctx.strokeStyle = accent;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+
+      ctx.fillStyle = isTerminal ? surface : ink;
+      ctx.fillText(i === 0 ? "•" : String.fromCharCode(labels[i]), x, y);
+    }
+  }
+
+  function rebuild() {
+    const patterns = stripNonAscii(patternsInput.value);
+    const nextText = sanitizeText(textInput.value);
+    try {
+      const next = new Visualizer(patterns, nextText);
+      stop();
+      viz = next;
+      text = nextText;
+      matched = [];
+      hopStates = new Set();
+      buildScan();
+      refreshScanClasses();
+      draw();
+      status.textContent = `${viz.node_count()} states`;
+    } catch (err) {
+      // A bad rebuild must not brick the demo the user was already looking
+      // at: the previous automaton (if any) stays exactly as it was.
+      status.textContent = err && err.message ? err.message : String(err);
+    }
+  }
+
+  function doStep() {
+    const advanced = viz.step();
+    hopStates = advanced ? new Set(readHops()) : new Set();
+    if (advanced) matched.push(...readMatches());
+    refreshScanClasses();
+    draw();
+    status.textContent = advanced ? `pos ${viz.pos()}/${text.length}` : "done";
+    return advanced;
+  }
+
+  // Generation-token play loop, copied from /demos/loader.js: a `gen`
+  // captured when `start()` runs is compared against the live `generation`
+  // on every tick, so a rapid pause/play double-click can't leave two
+  // chains of `requestAnimationFrame` calls racing each other and doubling
+  // the effective step rate.
+  function frame(gen) {
+    if (!running || gen !== generation) return;
+    requestAnimationFrame((ts) => {
+      if (!running || gen !== generation) return;
+      if (ts - lastStepAt >= STEP_MS) {
+        lastStepAt = ts;
+        if (!doStep()) {
+          stop({ quiet: true }); // doStep already set status to "done"
+          return;
+        }
+      }
+      frame(gen);
+    });
+  }
+
+  function start() {
+    if (running || !viz || viz.pos() >= text.length) return;
+    running = true;
+    generation++;
+    const gen = generation;
+    lastStepAt = performance.now();
+    playBtn.textContent = "Pause";
+    status.textContent = "playing";
+    frame(gen);
+  }
+
+  function stop({ quiet = false } = {}) {
+    if (!running) return;
+    running = false;
+    generation++; // orphans any pending frame from the current chain
+    playBtn.textContent = "Play";
+    // A manual pause leaves "playing" as the last status text forever
+    // unless something replaces it; every other caller (rebuild, step,
+    // reset) immediately sets its own status right after calling `stop`,
+    // so this only actually shows for the pause button itself.
+    if (!quiet && viz) status.textContent = `pos ${viz.pos()}/${text.length}`;
+  }
+
+  // The site's theme toggle mutates data-theme but dispatches no event. A
+  // playing automaton repaints on its own next tick, but a paused one
+  // would otherwise sit rendered in the wrong palette until the next step.
+  new MutationObserver(() => {
+    if (!running) draw();
+  }).observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+
+  rebuildBtn.addEventListener("click", rebuild);
+  playBtn.addEventListener("click", () => {
+    running ? stop() : start();
+  });
+  stepBtn.addEventListener("click", () => {
+    if (!viz) return;
+    stop();
+    doStep();
+  });
+  resetBtn.addEventListener("click", () => {
+    if (!viz) return;
+    stop();
+    viz.reset();
+    matched = [];
+    hopStates = new Set();
+    refreshScanClasses();
+    draw();
+    status.textContent = `${viz.node_count()} states`;
+  });
+
+  rebuild();
+
+  // Respect a reduced-motion preference: build and draw, but never
+  // auto-play or animate unbidden.
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    status.textContent = "paused — reduced motion";
+  }
+}
+
+main().catch((err) => {
+  const status = document.getElementById("ac-status");
+  if (status) status.textContent = "failed to load";
+  console.error("aho-corasick demo failed to load:", err);
+});

--- a/static/demos/aho-loader.js
+++ b/static/demos/aho-loader.js
@@ -128,22 +128,32 @@ async function main() {
       if (ys[i] > maxY) maxY = ys[i];
     }
     const pad = 26;
-    const spanX = Math.max(1e-6, maxX - minX);
-    const spanY = Math.max(1e-6, maxY);
-    const px = (x) => (spanX === 0 ? w / 2 : pad + ((x - minX) / spanX) * (w - 2 * pad));
+    // A single-node automaton (one pattern, one letter) has minX === maxX,
+    // so this raw span can genuinely be 0 — that's the case the centring
+    // branch below exists for. `spanY` has no equivalent case: `build`
+    // rejects zero patterns and every pattern folds to at least one
+    // letter, so the root always has at least one child and maxY >= 1.
+    const rawSpanX = maxX - minX;
+    const spanX = rawSpanX < 1e-6 ? 1 : rawSpanX;
+    const spanY = maxY;
+    const px = (x) => (rawSpanX < 1e-6 ? w / 2 : pad + ((x - minX) / spanX) * (w - 2 * pad));
     const py = (y) => pad + (y / spanY) * (h - 2 * pad);
 
-    const rule = cssVar("--rule");
     const ink = cssVar("--ink");
     const muted = cssVar("--muted");
     const accent = cssVar("--accent");
     const surface = cssVar("--surface");
+    const mono = cssVar("--font-mono") || "ui-monospace, monospace";
 
     const current = viz.current_state();
     const radius = Math.max(8, Math.min(14, w / (n + 4)));
 
-    // Trie edges: solid line, parent -> child.
-    ctx.strokeStyle = rule;
+    // Trie edges: solid line, parent -> child. `muted`, not `rule` — `rule`
+    // is a hairline border colour (~1.3:1 against the canvas background)
+    // meant for barely-there dividers, not a line the whole diagram's
+    // structure depends on being visible. Failure links share this colour
+    // too; solid-vs-dashed is what distinguishes the two, not colour.
+    ctx.strokeStyle = muted;
     ctx.lineWidth = 1.5;
     ctx.setLineDash([]);
     for (let i = 1; i < n; i++) {
@@ -180,7 +190,12 @@ async function main() {
     // outline.
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
-    ctx.font = `${Math.max(9, radius)}px var(--font-mono), ui-monospace, monospace`;
+    // The canvas font parser has no declaration context to resolve a CSS
+    // custom property against, so `ctx.font = "...px var(--font-mono)"`
+    // doesn't throw — it silently fails to parse and the whole assignment
+    // is ignored, leaving labels in the canvas default (10px sans-serif).
+    // `mono` above is resolved to a literal font-family list beforehand.
+    ctx.font = `${Math.max(9, radius)}px ${mono}`;
     for (let i = 0; i < n; i++) {
       const x = px(xs[i]), y = py(ys[i]);
       const isTerminal = terminal[i] === 1;
@@ -242,7 +257,13 @@ async function main() {
       status.textContent = `${viz.node_count()} states`;
     } catch (err) {
       // A bad rebuild must not brick the demo the user was already looking
-      // at: the previous automaton (if any) stays exactly as it was.
+      // at: the previous automaton (if any) stays exactly as it was. But if
+      // it was mid-play, that play loop is still running (the `stop()`
+      // above only runs on the success path) and would otherwise overwrite
+      // this error ~333ms later with its next "pos X/Y" tick — pause it
+      // first, quietly, so `stop()`'s own status update doesn't immediately
+      // clobber the error message we're about to show.
+      stop({ quiet: true });
       status.textContent = err && err.message ? err.message : String(err);
     }
   }
@@ -253,7 +274,7 @@ async function main() {
     if (advanced) matched.push(...readMatches());
     refreshScanClasses();
     draw();
-    status.textContent = advanced ? `pos ${viz.pos()}/${text.length}` : "done";
+    status.textContent = advanced ? `pos ${viz.pos()}/${text.length}` : "done — press Reset";
     return advanced;
   }
 
@@ -269,7 +290,7 @@ async function main() {
       if (ts - lastStepAt >= STEP_MS) {
         lastStepAt = ts;
         if (!doStep()) {
-          stop({ quiet: true }); // doStep already set status to "done"
+          stop({ quiet: true }); // doStep already set the "done" status
           return;
         }
       }
@@ -278,7 +299,12 @@ async function main() {
   }
 
   function start() {
-    if (running || !viz || viz.pos() >= text.length) return;
+    if (running || !viz) return;
+    if (viz.pos() >= text.length) {
+      // Silently doing nothing here reads as a broken button; say why.
+      status.textContent = "done — press Reset";
+      return;
+    }
     running = true;
     generation++;
     const gen = generation;
@@ -307,6 +333,14 @@ async function main() {
     if (!running) draw();
   }).observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
 
+  // `draw()` sizes the canvas backing store from the element's current CSS
+  // box on every call, so a paused canvas just needs to be told to redraw
+  // when that box changes (e.g. the rail collapsing to a top bar at the
+  // narrow-viewport breakpoint) — a running one already repaints every tick.
+  window.addEventListener("resize", () => {
+    if (!running) draw();
+  });
+
   rebuildBtn.addEventListener("click", rebuild);
   playBtn.addEventListener("click", () => {
     running ? stop() : start();
@@ -329,8 +363,14 @@ async function main() {
 
   rebuild();
 
-  // Respect a reduced-motion preference: build and draw, but never
-  // auto-play or animate unbidden.
+  // Unlike reaction-diffusion, this demo never auto-plays on load — `rebuild()`
+  // above only builds and draws — so this check doesn't currently gate any
+  // live animation. It's kept as documented intent rather than deleted: if
+  // a future change makes this demo auto-play by default too, reduced
+  // motion must be checked before that `start()` call, and this is where
+  // that check belongs. For now it only distinguishes the reduced-motion
+  // status message from the ordinary "N states" one, for anyone who
+  // expected autoplay and is wondering why the canvas is sitting still.
   if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
     status.textContent = "paused — reduced motion";
   }


### PR DESCRIPTION
The site's second WebAssembly demo, at `/demos/aho-corasick/`: build an Aho-Corasick automaton from editable patterns, watch the trie and failure links draw, then step or play text through it with matches highlighting in real DOM spans — the algorithm behind the transaction-tagging rewrite on the projects page.

## Shape

- `crates/demos/aho-corasick-demo` — automaton (trie, BFS failure links, merged outputs) and tidy-tree layout as pure Rust, 19 native tests with closed-form textbook fixtures; three of them exist specifically because reviews proved mutations survived without them (build-order, leaf-order, transitive inheritance).
- A `#[wasm_bindgen] Visualizer` exposing structure and per-step events as flat arrays; match ranges computed from folded pattern lengths via a tested pure function.
- A canvas loader mirroring the reaction-diffusion patterns (generation-token loop, theme MutationObserver, grouped guards), with the scan text rendered from the identical sanitized string the wasm stores so byte offsets and DOM spans cannot disagree.
- Starts paused (owner-ratified): the automaton is the content; read it, then play.
- CI builds both demo crates and fails if either's artifacts or page references are missing.

## Size

40,522 bytes of wasm, 16,892 gzipped. Loads only on its own page; every other page ships zero WebAssembly (asserted with exact `src` paths — `loader.js` is a substring of `aho-loader.js`, so the old assertion form would have been vacuous).

## Review trail

Five tasks, each gated; whole-branch review found one Critical (matched-text contrast at 3.83:1 in light theme, outside the WCAG test's reach because this demo introduced a new background pairing) and four loader Importants (invisible trie edges, a silently-ignored canvas font assignment, an unreachable centring branch, errors overwritten during playback) — all fixed and re-verified in-browser, and the AA machine check now covers the new pairing.

113 tests, clippy clean at `-D warnings`, zero lint suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)