### PR TITLE
Add CI security scanning and SHA-pin all GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    # Major-version bumps are left ungrouped so each one gets its own PR
+    # and review, rather than being bundled with routine updates.
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    # Covers both .github/workflows/*.yml, including the SHA-pinned actions
+    # in deploy.yml and security.yml — Dependabot understands the
+    # `owner/repo@<sha> # vX.Y.Z` comment convention and proposes updates
+    # to both the pin and the comment together.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,21 +8,21 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
 
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
       with:
         components: clippy
         targets: wasm32-unknown-unknown
 
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
     - name: Lint
       run: cargo clippy --all-targets -- -D warnings
@@ -67,15 +67,18 @@ jobs:
         ls -la dist/resume/
 
     - name: Setup Pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
 
-    - uses: actions/upload-pages-artifact@v3
+    - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
       with:
         path: 'dist'
 
   deploy:
     needs: build
     if: github.ref == 'refs/heads/master'
+    permissions:
+      pages: write # required by actions/deploy-pages to publish the build
+      id-token: write # required by actions/deploy-pages for OIDC auth
     concurrency:
       group: "pages"
       cancel-in-progress: false
@@ -85,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,55 @@
+name: Security Scans
+
+on:
+  pull_request:
+  schedule:
+    # 03:17 UTC every Monday — off-peak, avoids the top-of-hour thundering herd.
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          command-arguments: advisories licenses sources -W unmaintained -W unsound
+
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          inputs: .github/workflows/
+          # No Advanced Security / code-scanning integration on this repo, so
+          # findings are printed to the job log and fail the job directly
+          # instead of being uploaded to the (unused) Security tab.
+          advanced-security: false
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # User account repo: gitleaks-action is free here, no
+          # GITLEAKS_LICENSE secret needed (that's only for organizations).
+          # PR commenting is disabled rather than granting pull-requests:
+          # write beyond the workflow's read-only permissions block.
+          GITLEAKS_ENABLE_COMMENTS: "false"

--- a/crates/demos/aho-corasick-demo/Cargo.toml
+++ b/crates/demos/aho-corasick-demo/Cargo.toml
@@ -3,6 +3,7 @@ name = "aho-corasick-demo"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/demos/reaction-diffusion/Cargo.toml
+++ b/crates/demos/reaction-diffusion/Cargo.toml
@@ -3,6 +3,7 @@ name = "reaction-diffusion"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/site/Cargo.toml
+++ b/crates/site/Cargo.toml
@@ -3,6 +3,7 @@ name = "site"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
+publish = false
 
 [dependencies]
 maud = "0.27"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,70 @@
+# cargo-deny policy for this repo.
+#
+# Threat model: static site with no server code and no user data. What
+# matters is the dependency tree that feeds the CI pipeline (34 crates as of
+# writing) and the JavaScript/wasm we publish to visitors. This file is
+# checked by `cargo deny check advisories licenses sources` in
+# .github/workflows/security.yml, and can be run locally the same way:
+#
+#   cargo deny check
+#
+# Regenerate/inspect with `cargo deny check licenses` after a `cargo update`
+# if a new dependency introduces a license not covered below.
+
+[advisories]
+# Known security vulnerabilities (RUSTSEC advisories) always fail this
+# check in current cargo-deny — there is no lint-level knob for it, so
+# there is nothing to configure here to "deny vulnerabilities".
+ignore = []
+
+# Unmaintained/unsound advisories are softer signals than a vulnerability
+# (a crate can be "unmaintained" and still be perfectly fine). cargo-deny
+# 0.20 doesn't offer a true warn-vs-deny severity for these two categories
+# in this config file — the `unmaintained`/`unsound` fields only choose
+# *which* crates are checked (all/workspace/transitive/none), and a match
+# always fails the check. We want them checked (not silently skipped) but
+# not yet allowed to fail CI, so we check "all" crates here and downgrade
+# both codes to warnings on the command line in the workflow
+# (`-W unmaintained -W unsound`). Revisit and tighten to deny once the
+# project has lived with visibility on these for a while.
+unmaintained = "all"
+unsound = "all"
+
+# A yanked crate version being in the lockfile means `cargo update` needs
+# to happen; fail the check so it doesn't go unnoticed.
+yanked = "deny"
+
+[licenses]
+# Explicit allowlist derived from what `cargo deny check licenses` reports
+# against the actual tree (34 crates, pulled in by the wasm-bindgen demos
+# and the maud/serde/toml/anyhow site generator):
+#   - MIT, Apache-2.0: the vast majority of the tree (wasm-bindgen family,
+#     serde family, syn/quote/proc-macro2, maud, anyhow, toml family, ...)
+#   - Unicode-3.0: unicode-ident's Unicode data tables
+#     ("(MIT OR Apache-2.0) AND Unicode-3.0")
+# winnow (MIT-only) and version_check/proc-macro2-diagnostics (older
+# "MIT/Apache-2.0" separator syntax) are covered by MIT/Apache-2.0 above.
+# No Zlib or other license currently appears in the tree — nothing
+# speculative is allowed here; add to this list only after re-running
+# `cargo deny check licenses` and seeing a real rejection.
+allow = ["MIT", "Apache-2.0", "Unicode-3.0"]
+
+# Default confidence threshold (0.8) for matching license text.
+confidence-threshold = 0.8
+
+[licenses.private]
+# The three workspace crates (site, reaction-diffusion, aho-corasick-demo)
+# carry no `license` field because they are never published — they're
+# marked `publish = false` in their Cargo.toml, which is what this flag
+# keys off of to skip the license check for them.
+ignore = true
+
+[sources]
+# crates-io only: reject anything from a registry or git source that
+# isn't the standard crates.io index. This is a supply-chain control, not
+# just a warning — an unexpected registry or git dependency is exactly
+# the kind of thing that should stop the build.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
Security scanning and supply-chain hardening, fitted to this site's actual threat model: no server code and no user data, so what matters is the CI pipeline (it holds a token and publishes the JavaScript visitors run) and the dependency tree feeding it.

## New: `.github/workflows/security.yml`

Three independent jobs on PRs, weekly schedule, and manual dispatch — `contents: read` only:

- **cargo-deny** — RustSec advisories, license allowlist derived from the actual tree (MIT / Apache-2.0 / Unicode-3.0, nothing speculative), crates-io-only sources. Unmaintained/unsound advisories are checked but warn-level for now, with the reasoning documented in `deny.toml`.
- **zizmor** — lints the workflows themselves, including this one.
- **gitleaks** — full-history secret scan (86 commits, clean).

## Hardened: `deploy.yml`

Zizmor's findings on the existing workflow were fixed, not ignored: all actions SHA-pinned, `pages`/`id-token` permissions moved from workflow level to the deploy job only, and `persist-credentials: false` on checkouts (the resume fetch uses its own token header — traced, not assumed).

## Pins and updates

Every `uses:` is pinned to a full commit SHA with the version as a comment — including correctly dereferencing annotated tags to commit SHAs (two actions had that trap). Review independently verified 10/10 pins against the live tags. Dependabot watches both cargo and github-actions weekly, minor+patch grouped.

Workspace crates gain `publish = false` (with the cargo-deny private-crate exemption) rather than having a license declared on the owner's behalf.

All three scanners pass locally; this PR's own checks prove them in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)