### PR TITLE
CSP groundwork: hash drift gate, style-attribute removal, paste-ready edge headers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,9 @@ jobs:
     - name: Build site
       run: cargo run -p site -- --strict
 
+    - name: Verify CSP hashes
+      run: ./scripts/check-csp-hashes.sh
+
     - name: Verify wasm shipped
       run: |
         test -f dist/demos/reaction-diffusion/reaction_diffusion_bg.wasm

--- a/crates/site/src/pages/index.rs
+++ b/crates/site/src/pages/index.rs
@@ -14,7 +14,7 @@ pub fn render(site: &Site) -> Markup {
         }
         p .lede { (site.lede) }
         p .prose { (site.bio) }
-        p .mono style="margin-top:2rem" { (site.role) }
+        p .mono .role-line { (site.role) }
 
         div .section-head {
             span .mono { "Selected Work" }

--- a/crates/site/src/theme.rs
+++ b/crates/site/src/theme.rs
@@ -163,6 +163,7 @@ h1 {{ font-size: 54px; line-height: 1.02; letter-spacing: -0.035em; font-weight:
 h2 {{ font-size: 24px; letter-spacing: -0.02em; font-weight: 600; }}
 .lede {{ font-size: 17px; line-height: 1.62; max-width: var(--measure); margin: 0 0 calc(var(--space) * 1.75); }}
 .prose {{ font-size: 14.5px; line-height: 1.65; max-width: var(--measure); color: var(--muted); }}
+.role-line {{ margin-top: 2rem; }}
 
 .section-head {{
   display: flex; justify-content: space-between; align-items: baseline;
@@ -316,6 +317,15 @@ mod tests {
         // this stylesheet.
         let css = stylesheet();
         assert!(css.contains(".resume-page {"), "stylesheet missing .resume-page: {css}");
+    }
+
+    #[test]
+    fn role_line_class_used_in_markup_is_defined_here() {
+        // pages/index.rs writes `.role-line` with nothing tying it to this
+        // stylesheet — it replaces a `style="margin-top:2rem"` attribute so
+        // the CSP can drop `style-src-attr 'unsafe-inline'`.
+        let css = stylesheet();
+        assert!(css.contains(".role-line {"), "stylesheet missing .role-line: {css}");
     }
 
     #[test]

--- a/scripts/check-csp-hashes.sh
+++ b/scripts/check-csp-hashes.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Drift gate for the Content-Security-Policy the owner pastes into
+# Cloudflare (see security/cloudflare-headers.md). Recomputes the sha256
+# of every inline <script> body actually shipped in dist/**/*.html and
+# compares that set, exactly, against the non-comment lines of
+# security/csp-hashes.txt — the file the Cloudflare rule mirrors.
+#
+# A hash present in dist but missing from the file means a script
+# changed (or a new one was added) and the CSP would now block it.
+# A hash present in the file but absent from dist is just as much
+# drift: a stale allowance nobody would ever notice go unused, until
+# the day it silently permits something it shouldn't.
+#
+# Run after `cargo run -p site -- --strict` has produced dist/.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DIST=dist
+HASHES_FILE=security/csp-hashes.txt
+
+if [ ! -d "$DIST" ]; then
+    echo "Error: $DIST not found — build the site first (cargo run -p site -- --strict)" >&2
+    exit 1
+fi
+
+if [ ! -f "$HASHES_FILE" ]; then
+    echo "Error: $HASHES_FILE not found" >&2
+    exit 1
+fi
+
+python3 - "$DIST" "$HASHES_FILE" <<'PYEOF'
+import base64
+import hashlib
+import html
+import re
+import sys
+from pathlib import Path
+
+dist_dir, hashes_file = sys.argv[1], sys.argv[2]
+
+script_re = re.compile(r"<script(?:\s[^>]*)?>(.*?)</script>", re.DOTALL | re.IGNORECASE)
+
+# hash -> first snippet seen with that hash, for readable failure output.
+dist_hashes = {}
+for path in sorted(Path(dist_dir).rglob("*.html")):
+    content = path.read_text(encoding="utf-8")
+    for match in script_re.finditer(content):
+        body = match.group(1)
+        if body.strip() == "":
+            # External/module scripts (<script src="...">) have no body
+            # to hash and aren't covered by this policy's script-src
+            # hash allowlist.
+            continue
+        digest = base64.b64encode(hashlib.sha256(body.encode("utf-8")).digest()).decode()
+        sha = f"sha256-{digest}"
+        dist_hashes.setdefault(sha, (body[:60].replace("\n", "\\n"), str(path)))
+
+allowed_hashes = set()
+for line in Path(hashes_file).read_text(encoding="utf-8").splitlines():
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        continue
+    allowed_hashes.add(stripped)
+
+dist_set = set(dist_hashes.keys())
+
+extra_in_dist = dist_set - allowed_hashes
+stale_in_file = allowed_hashes - dist_set
+
+ok = True
+
+if extra_in_dist:
+    ok = False
+    print("CSP DRIFT: inline <script> hash(es) in dist/ not listed in " + hashes_file + ":")
+    for sha in sorted(extra_in_dist):
+        snippet, path = dist_hashes[sha]
+        print(f"  {sha}")
+        print(f"    first 60 chars: {html.unescape(snippet)!r}")
+        print(f"    found in: {path}")
+
+if stale_in_file:
+    ok = False
+    print("CSP DRIFT: hash(es) listed in " + hashes_file + " but not found in any dist/**/*.html script:")
+    for sha in sorted(stale_in_file):
+        print(f"  {sha}")
+
+if not ok:
+    print()
+    print("The Cloudflare CSP and " + hashes_file + " must list exactly the hashes")
+    print("of the inline scripts the site currently ships. Update both together.")
+    sys.exit(1)
+
+print(f"OK: {len(dist_set)} inline <script> hash(es) in dist/ match {hashes_file} exactly.")
+for sha in sorted(dist_set):
+    snippet, _ = dist_hashes[sha]
+    print(f"  {sha}  ({html.unescape(snippet)!r}...)")
+PYEOF

--- a/security/cloudflare-headers.md
+++ b/security/cloudflare-headers.md
@@ -1,0 +1,142 @@
+# Cloudflare edge headers
+
+These are applied manually in the Cloudflare dashboard for `paul-maxwell.com`
+— the repo has no Cloudflare API access and doesn't push these. This
+document is the paste-ready reference; `security/csp-hashes.txt` is the
+source of truth for the two hash values below.
+
+## 1. Transform Rule: response headers
+
+**Rules → Overview → Create rule → Modify Response Header.**
+
+- Rule name: e.g. `Security headers`
+- When incoming requests match: **All incoming requests** (this is a
+  single-purpose static site — every response gets the same headers)
+- Then: **Set static** for each of the following
+
+### `Content-Security-Policy`
+
+```
+default-src 'none'; script-src 'self' 'sha256-R04+76miHHnkN/gWcsxD3a9pWM52m8KuVPq/ujEngqE=' 'sha256-VW0DRQl3KZ97qykJSzGadSViC3KuBUzcUoADouFhSk8=' 'wasm-unsafe-eval'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+```
+
+Directive by directive:
+
+- `default-src 'none'` — deny-by-default baseline. Every resource this
+  site ever loads is same-origin (fonts, CSS, images, wasm), so nothing
+  needs a broader fallback.
+- `script-src 'self' 'sha256-...' 'sha256-...' 'wasm-unsafe-eval'` —
+  scripts must come from the same origin, or be one of the site's two
+  known inline scripts (theme-restore in `<head>`, theme-toggle in the
+  rail — see `security/csp-hashes.txt`). `'wasm-unsafe-eval'` is required
+  because both demo pages (`/demos/reaction-diffusion/`,
+  `/demos/aho-corasick/`) call `WebAssembly.instantiateStreaming`, which
+  browsers gate behind this token even though it's a normal, safe wasm
+  load path (not `eval`-style string execution).
+- `style-src 'self'` — all CSS is the one same-origin stylesheet
+  (`/style.css`); no inline `style=""` attributes or `<style>` blocks
+  ship anywhere (verified by `grep -rc 'style="' dist` in CI — see
+  `.github/workflows/deploy.yml`), so no `'unsafe-inline'` is needed.
+- `img-src 'self'` — all images (favicon, apple-touch-icon, og-image,
+  resume page SVGs) are same-origin.
+- `font-src 'self'` — both webfonts (`InterVariable.woff2`,
+  `JetBrainsMono.woff2`) are served from `/fonts/`, same-origin.
+- `connect-src 'self'` — the wasm demos fetch their `.wasm` binaries via
+  `WebAssembly.instantiateStreaming(fetch(...))`, a same-origin network
+  request that `connect-src` (not `script-src`) governs.
+- `base-uri 'none'` — nothing on the site needs a `<base>` tag; this
+  closes off base-tag injection as an attack vector.
+- `form-action 'none'` — the site has no forms.
+- `frame-ancestors 'none'` — the site should never be framed by another
+  origin (clickjacking defense; the modern replacement for
+  `X-Frame-Options`).
+
+### `X-Content-Type-Options`
+
+```
+nosniff
+```
+
+Stops browsers from MIME-sniffing responses into an unintended content
+type (e.g. treating a response as executable script when it isn't).
+
+### `Referrer-Policy`
+
+```
+strict-origin-when-cross-origin
+```
+
+Sends the full URL as referrer for same-origin navigation, but only the
+origin (no path) cross-origin — reasonable default that doesn't leak
+page paths to third parties while still letting analytics on other sites
+see where a click came from.
+
+### `Permissions-Policy`
+
+```
+camera=(), microphone=(), geolocation=()
+```
+
+The site uses none of these; disable them explicitly so an embedded
+third party (there shouldn't be one, but defense in depth) can't request
+them either.
+
+## 2. HSTS
+
+**SSL/TLS → Edge Certificates → HTTP Strict Transport Security.**
+
+- **Max age**: 12 months
+- **Apply HSTS policy to subdomains (includeSubDomains)**: **off**
+  initially. Reason: turning this on commits every current and future
+  subdomain of `paul-maxwell.com` to HTTPS-only, permanently (browsers
+  cache it for the max-age). If a subdomain is ever stood up that can't
+  do HTTPS yet — a quick redirect target, a third-party CNAME during
+  setup, anything — `includeSubDomains` bricks it for every visitor who
+  already has the policy cached, with no fast way to undo it. Revisit
+  this once every subdomain that exists or is planned is confirmed
+  HTTPS-only; there's no urgency to turn it on early.
+- **Preload**: off. Preload submission is effectively permanent (it ships
+  in browser source trees) and is only worth doing after `includeSubDomains`
+  has been on, stable, and uneventful for a while.
+
+## 3. Verify afterwards
+
+```
+curl -sI https://paul-maxwell.com/ | grep -i -E 'content-security-policy|x-content-type-options|referrer-policy|permissions-policy|strict-transport-security'
+```
+
+Expected (wrapped for readability; the real header is one line):
+
+```
+content-security-policy: default-src 'none'; script-src 'self' 'sha256-R04+76miHHnkN/gWcsxD3a9pWM52m8KuVPq/ujEngqE=' 'sha256-VW0DRQl3KZ97qykJSzGadSViC3KuBUzcUoADouFhSk8=' 'wasm-unsafe-eval'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+x-content-type-options: nosniff
+referrer-policy: strict-origin-when-cross-origin
+permissions-policy: camera=(), microphone=(), geolocation=()
+strict-transport-security: max-age=31536000
+```
+
+**Warning:** a typo in the CSP (wrong hash, missing `'self'`, a stray
+character) doesn't produce an error page — it silently blocks the
+site's JS. The theme toggle and both wasm demos degrade completely
+invisibly on a bad CSP. After applying the rule, load the site with the
+browser devtools console open and check for CSP violation messages, then
+manually exercise:
+
+- the dark-mode toggle button (rail),
+- `/demos/reaction-diffusion/` (canvas should render and respond to
+  input, not stay blank),
+- `/demos/aho-corasick/` (same).
+
+## 4. Keeping this in sync
+
+`security/csp-hashes.txt` is the source of truth for the `script-src`
+hash values above, and `scripts/check-csp-hashes.sh` (run in CI on every
+build, see `.github/workflows/deploy.yml`) fails the build if the hashes
+in that file ever stop matching what the built site actually ships.
+
+That CI check only guards the repo side. It cannot see or update the
+Cloudflare rule. If either inline script's bytes ever change (a hash in
+`security/csp-hashes.txt` changes as a result), **the Cloudflare
+Transform Rule's CSP must be updated with the new hash in the same
+change** — otherwise the next deploy ships a script the edge CSP no
+longer allows, and it silently stops running for every visitor.

--- a/security/csp-hashes.txt
+++ b/security/csp-hashes.txt
@@ -1,0 +1,29 @@
+# CSP source of truth for this site's inline <script> elements.
+#
+# The site emits exactly two distinct inline scripts, identical on every
+# page they appear on:
+#
+#   - head/theme-restore  (crates/site/src/components/shell.rs)
+#     Runs in <head> before first paint. Reads the persisted theme choice
+#     out of localStorage and, if it's "dark", sets
+#     document.documentElement.dataset.theme = "dark" before any content
+#     renders, so there's no light-to-dark flash on reload.
+#
+#   - rail/theme-toggle  (crates/site/src/components/rail.rs)
+#     Wires up the dark-mode toggle button in the rail: syncs its label
+#     and aria-pressed state to the current theme, and flips the theme
+#     (updating both the DOM attribute and localStorage) on click.
+#
+# scripts/check-csp-hashes.sh recomputes the sha256 of every inline
+# <script> body in dist/**/*.html and diffs the resulting set against the
+# non-comment lines below, exactly (extra dist hash or a stale unused
+# line here are both treated as drift and fail the build).
+#
+# The Cloudflare Transform Rule CSP (see security/cloudflare-headers.md)
+# must list exactly these two hashes in its script-src directive. If
+# either inline script's bytes ever change, both this file and the
+# Cloudflare rule must be updated together, or the site's JS silently
+# breaks in production.
+
+sha256-R04+76miHHnkN/gWcsxD3a9pWM52m8KuVPq/ujEngqE=
+sha256-VW0DRQl3KZ97qykJSzGadSViC3KuBUzcUoADouFhSk8=


### PR DESCRIPTION
Prepares the repo for a strict Content-Security-Policy applied at the Cloudflare edge.

- Removes the site's one remaining `style=""` attribute (a class carries the identical declaration), so the CSP needs no `'unsafe-inline'` anywhere.
- `security/csp-hashes.txt` becomes the committed source of truth for the two inline-script hashes; `scripts/check-csp-hashes.sh` recomputes every inline script in the built output and fails on drift **in either direction** (new/changed script, or stale allowance). Wired into the deploy build as `Verify CSP hashes`; the gate was watched failing on a planted stale hash before being trusted.
- `security/cloudflare-headers.md`: the paste-ready rules — strict CSP (`default-src 'none'`, hashed inline scripts, `'wasm-unsafe-eval'` for the demos), nosniff, referrer and permissions policies, HSTS guidance (deliberately no `includeSubDomains` initially, reasoning documented) — with a directive-by-directive rationale and a post-apply verification checklist.

90 tests, clippy clean. The edge rule itself is applied manually by the owner; CI guards the repo half of the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)